### PR TITLE
support eslint@>=1.0.0-rc-1

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "homepage": "https://github.com/babel/eslint-plugin-babel#readme",
   "peerDependencies": {
-    "eslint": ">=0.8.0"
+    "eslint": ">=0.8.0 || >=1.0.0-rc-1"
   },
   "devDependencies": {
     "babel-eslint": "^3.1.17",


### PR DESCRIPTION
it works fine for me, but:

```
npm ERR! peerinvalid The package eslint@1.0.0-rc-1 does not satisfy its siblings' peerDependencies requirements!
npm ERR! peerinvalid Peer eslint-plugin-babel@1.2.0 wants eslint@>=0.8.0
```