### PR TITLE
add arrow-parens to index.js

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,11 +6,13 @@ module.exports = {
     'new-cap': require('./rules/new-cap'),
     'object-curly-spacing': require('./rules/object-curly-spacing'),
     'object-shorthand': require('./rules/object-shorthand'),
+    'arrow-parens': require('./rules/arrow-parens'),
   },
   rulesConfig: {
     'generator-star-spacing': 0,
     'new-cap': 0,
     'object-curly-spacing': 0,
     'object-shorthand': 0,
+    'arrow-parens': 0,
   }
 };


### PR DESCRIPTION
eslint-plugin-babel@2.1.0 added the arrow-parens rule, however trying to use it causes a not found error:

```
1:1  warning  Definition for rule 'babel/arrow-parens' was not found  babel/arrow-parens
```

arrow-parens needs to be added to index.js