### PR TITLE
Fix typo in README rules section

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,4 +42,4 @@ Each rule corresponds to a core `eslint` rule, and has the same options.
 - `babel/object-curly-spacing`: doesn't complain about `export x from "mod";` or `export * as x from "mod";`
 - `babel/object-shorthand`: doesn't fail when using object spread (`...obj`)
 - `babel/arrow-parens`: Handles async functions correctly
-- `bael/no-await-in-loop`: guard against awaiting async functions inside of a loop
+- `babel/no-await-in-loop`: guard against awaiting async functions inside of a loop


### PR DESCRIPTION
Corrected `bael` to `babel`.