### PR TITLE
Add type annotations to arrow-parens "as-needed"

### DIFF
--- a/rules/arrow-parens.js
+++ b/rules/arrow-parens.js
@@ -24,7 +24,9 @@ module.exports = function(context) {
         if (node.async) token = context.getTokenAfter(token);
 
         // as-needed: x => x
-        if (asNeeded && node.params.length === 1 && node.params[0].type === "Identifier") {
+        if (asNeeded && node.params.length === 1
+                && node.params[0].type === "Identifier"
+                && node.params[0].typeAnnotation === undefined) {
             if (token.type === "Punctuator" && token.value === "(") {
                 context.report(node, asNeededMessage);
             }

--- a/tests/arrow-parens.js
+++ b/tests/arrow-parens.js
@@ -46,6 +46,7 @@ var valid = [
     { code: "(a = 10) => {}", options: ["as-needed"], ecmaFeatures: { arrowFunctions: true, destructuring: true, defaultParams: true } },
     { code: "(...a) => a[0]", options: ["as-needed"], ecmaFeatures: { arrowFunctions: true, restParams: true } },
     { code: "(a, b) => {}", options: ["as-needed"], ecmaFeatures: { arrowFunctions: true } },
+    ok("(a: string) => a", ["as-needed"]),
 
     // async
     ok("async () => {}"),


### PR DESCRIPTION
When using optional type annotations, parentheses are required even for
single-argument arrow functions. Check for a `typeAnnotation` on the
single param and allow parentheses if it exists.

    // good with "as-needed"
    a => 5;
    (a: string) => 5; // Previously this reported an error

    // bad with "as-needed"
    (a) => 5;