### PR TITLE
Implement a fixer for arrow-parens

### DIFF
--- a/tests/arrow-parens.js
+++ b/tests/arrow-parens.js
@@ -157,6 +157,24 @@ var invalid = [
         }]
     },
 
+    // Autofix for arrow-parens "as-needed"
+    {
+        code: "(b) => b",
+        options: ["as-needed"],
+        ecmaFeatures: { arrowFunctions: true },
+        errors: [{
+            output: "b => b"
+        }]
+    },
+    {
+        code: "( a ) => 5;",
+        options: ["as-needed"],
+        ecmaFeatures: { arrowFunctions: true },
+        errors: [{
+            output: "a => 5;"
+        }]
+    },
+
     // async
     err('async a => {}', [
       { message: 'Expected parentheses around arrow function argument.' },


### PR DESCRIPTION
Enable ESLint to fix the "as-needed" arrow parens case when parentheses
exist but should be omitted. For example:

```
(foo) => 5;
( bar ) => true;
```

with `eslint --fix` would become:

```
foo => 5;
bar => true;
```