### PR TITLE
Run Travis CI in same Node versions as babel-eslint

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,11 @@
 ---
 git:
   depth: 1
+sudo: false
 language: node_js
 node_js:
+  - '0.10'
   - '0.12'
-  - 'io.js'
+  - '4'
+  - '5'
+  - '6'


### PR DESCRIPTION
There wasn't an issue for this, but I figured the CI tests should be running in the same versions that `babel-eslint`'s tests are being run. Here's the [babel-eslint .travis.yml file](https://github.com/babel/babel-eslint/blob/master/.travis.yml).