### PR TITLE
Fix arrow-parens "as-needed" return type annotations

### DIFF
--- a/rules/arrow-parens.js
+++ b/rules/arrow-parens.js
@@ -26,7 +26,8 @@ module.exports = function(context) {
         // as-needed: x => x
         if (asNeeded && node.params.length === 1
                 && node.params[0].type === "Identifier"
-                && node.params[0].typeAnnotation === undefined) {
+                && node.params[0].typeAnnotation === undefined
+                && (node.returnType && node.returnType.typeAnnotation) === undefined) {
             if (token.type === "Punctuator" && token.value === "(") {
                 context.report({
                     node: node,

--- a/tests/rules/arrow-parens.js
+++ b/tests/rules/arrow-parens.js
@@ -48,6 +48,8 @@ var valid = [
     { code: "(...a) => a[0]", options: ["as-needed"], ecmaFeatures: { arrowFunctions: true, restParams: true } },
     { code: "(a, b) => {}", options: ["as-needed"], ecmaFeatures: { arrowFunctions: true } },
     ok("(a: string) => a", ["as-needed"]),
+    ok("(a: string): string => a", ["as-needed"]),
+    ok("(a): string => a", ["as-needed"]),
 
     // async
     ok("async () => {}"),


### PR DESCRIPTION
Fixes arrow-parens "as-needed" to preserve parens when there is a return-type without any params-types.

Expanding on https://github.com/babel/eslint-plugin-babel/pull/44/files.
