### PR TITLE
Added `babel/no-invalid-this`

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,8 @@ original ones as well!).
     "babel/arrow-parens": 1,
     "babel/no-await-in-loop": 1,
     "babel/flow-object-type": 1,
-    "babel/func-params-comma-dangle": 1
+    "babel/func-params-comma-dangle": 1,
+    "babel/no-invalid-this": 1
   }
 }
 ```
@@ -50,6 +51,7 @@ Each rule corresponds to a core `eslint` rule, and has the same options.
 - `babel/object-curly-spacing`: doesn't complain about `export x from "mod";` or `export * as x from "mod";` (🛠 )
 - `babel/object-shorthand`: doesn't fail when using object spread (`...obj`)
 - `babel/arrow-parens`: Handles async functions correctly (🛠 )
+- `babel/no-invalid-this`: doesn't fail when inside class properties (`class A { a = this.b; }`)
 
 The following rules are not in `eslint`, but are relevant only to syntax that is not specified by
 the current JavaScript standard or supported by `eslint`.

--- a/ast-utils.js
+++ b/ast-utils.js
@@ -1,0 +1,742 @@
+/**
+ * @fileoverview Common utils for AST.
+ * @author Gyandeep Singh
+ */
+
+"use strict";
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+const esutils = require("esutils");
+
+//------------------------------------------------------------------------------
+// Helpers
+//------------------------------------------------------------------------------
+
+const anyFunctionPattern = /^(?:Function(?:Declaration|Expression)|ArrowFunctionExpression)$/;
+const anyLoopPattern = /^(?:DoWhile|For|ForIn|ForOf|While)Statement$/;
+const arrayOrTypedArrayPattern = /Array$/;
+const arrayMethodPattern = /^(?:every|filter|find|findIndex|forEach|map|some)$/;
+const bindOrCallOrApplyPattern = /^(?:bind|call|apply)$/;
+const breakableTypePattern = /^(?:(?:Do)?While|For(?:In|Of)?|Switch)Statement$/;
+const thisTagPattern = /^[\s\*]*@this/m;
+
+/**
+ * Checks reference if is non initializer and writable.
+ * @param {Reference} reference - A reference to check.
+ * @param {int} index - The index of the reference in the references.
+ * @param {Reference[]} references - The array that the reference belongs to.
+ * @returns {boolean} Success/Failure
+ * @private
+ */
+function isModifyingReference(reference, index, references) {
+    const identifier = reference.identifier;
+
+    /*
+     * Destructuring assignments can have multiple default value, so
+     * possibly there are multiple writeable references for the same
+     * identifier.
+     */
+    const modifyingDifferentIdentifier = index === 0 ||
+        references[index - 1].identifier !== identifier;
+
+    return (identifier &&
+        reference.init === false &&
+        reference.isWrite() &&
+        modifyingDifferentIdentifier
+    );
+}
+
+/**
+ * Checks whether the given string starts with uppercase or not.
+ *
+ * @param {string} s - The string to check.
+ * @returns {boolean} `true` if the string starts with uppercase.
+ */
+function startsWithUpperCase(s) {
+    return s[0] !== s[0].toLocaleLowerCase();
+}
+
+/**
+ * Checks whether or not a node is a constructor.
+ * @param {ASTNode} node - A function node to check.
+ * @returns {boolean} Wehether or not a node is a constructor.
+ */
+function isES5Constructor(node) {
+    return (node.id && startsWithUpperCase(node.id.name));
+}
+
+/**
+ * Finds a function node from ancestors of a node.
+ * @param {ASTNode} node - A start node to find.
+ * @returns {Node|null} A found function node.
+ */
+function getUpperFunction(node) {
+    while (node) {
+        if (anyFunctionPattern.test(node.type)) {
+            return node;
+        }
+        node = node.parent;
+    }
+    return null;
+}
+
+/**
+ * Checks whether or not a node is `null` or `undefined`.
+ * @param {ASTNode} node - A node to check.
+ * @returns {boolean} Whether or not the node is a `null` or `undefined`.
+ * @public
+ */
+function isNullOrUndefined(node) {
+    return (
+        (node.type === "Literal" && node.value === null) ||
+        (node.type === "Identifier" && node.name === "undefined") ||
+        (node.type === "UnaryExpression" && node.operator === "void")
+    );
+}
+
+/**
+ * Checks whether or not a node is callee.
+ * @param {ASTNode} node - A node to check.
+ * @returns {boolean} Whether or not the node is callee.
+ */
+function isCallee(node) {
+    return node.parent.type === "CallExpression" && node.parent.callee === node;
+}
+
+/**
+ * Checks whether or not a node is `Reclect.apply`.
+ * @param {ASTNode} node - A node to check.
+ * @returns {boolean} Whether or not the node is a `Reclect.apply`.
+ */
+function isReflectApply(node) {
+    return (
+        node.type === "MemberExpression" &&
+        node.object.type === "Identifier" &&
+        node.object.name === "Reflect" &&
+        node.property.type === "Identifier" &&
+        node.property.name === "apply" &&
+        node.computed === false
+    );
+}
+
+/**
+ * Checks whether or not a node is `Array.from`.
+ * @param {ASTNode} node - A node to check.
+ * @returns {boolean} Whether or not the node is a `Array.from`.
+ */
+function isArrayFromMethod(node) {
+    return (
+        node.type === "MemberExpression" &&
+        node.object.type === "Identifier" &&
+        arrayOrTypedArrayPattern.test(node.object.name) &&
+        node.property.type === "Identifier" &&
+        node.property.name === "from" &&
+        node.computed === false
+    );
+}
+
+/**
+ * Checks whether or not a node is a method which has `thisArg`.
+ * @param {ASTNode} node - A node to check.
+ * @returns {boolean} Whether or not the node is a method which has `thisArg`.
+ */
+function isMethodWhichHasThisArg(node) {
+    while (node) {
+        if (node.type === "Identifier") {
+            return arrayMethodPattern.test(node.name);
+        }
+        if (node.type === "MemberExpression" && !node.computed) {
+            node = node.property;
+            continue;
+        }
+
+        break;
+    }
+
+    return false;
+}
+
+/**
+ * Checks whether or not a node has a `@this` tag in its comments.
+ * @param {ASTNode} node - A node to check.
+ * @param {SourceCode} sourceCode - A SourceCode instance to get comments.
+ * @returns {boolean} Whether or not the node has a `@this` tag in its comments.
+ */
+function hasJSDocThisTag(node, sourceCode) {
+    const jsdocComment = sourceCode.getJSDocComment(node);
+
+    if (jsdocComment && thisTagPattern.test(jsdocComment.value)) {
+        return true;
+    }
+
+    // Checks `@this` in its leading comments for callbacks,
+    // because callbacks don't have its JSDoc comment.
+    // e.g.
+    //     sinon.test(/* @this sinon.Sandbox */function() { this.spy(); });
+    return sourceCode.getComments(node).leading.some(function(comment) {
+        return thisTagPattern.test(comment.value);
+    });
+}
+
+/**
+ * Determines if a node is surrounded by parentheses.
+ * @param {SourceCode} sourceCode The ESLint source code object
+ * @param {ASTNode} node The node to be checked.
+ * @returns {boolean} True if the node is parenthesised.
+ * @private
+ */
+function isParenthesised(sourceCode, node) {
+    const previousToken = sourceCode.getTokenBefore(node),
+        nextToken = sourceCode.getTokenAfter(node);
+
+    return Boolean(previousToken && nextToken) &&
+        previousToken.value === "(" && previousToken.range[1] <= node.range[0] &&
+        nextToken.value === ")" && nextToken.range[0] >= node.range[1];
+}
+
+//------------------------------------------------------------------------------
+// Public Interface
+//------------------------------------------------------------------------------
+
+module.exports = {
+
+    /**
+     * Determines whether two adjacent tokens are on the same line.
+     * @param {Object} left - The left token object.
+     * @param {Object} right - The right token object.
+     * @returns {boolean} Whether or not the tokens are on the same line.
+     * @public
+     */
+    isTokenOnSameLine(left, right) {
+        return left.loc.end.line === right.loc.start.line;
+    },
+
+    isNullOrUndefined,
+    isCallee,
+    isES5Constructor,
+    getUpperFunction,
+    isArrayFromMethod,
+    isParenthesised,
+
+    /**
+     * Checks whether or not a given node is a string literal.
+     * @param {ASTNode} node - A node to check.
+     * @returns {boolean} `true` if the node is a string literal.
+     */
+    isStringLiteral(node) {
+        return (
+            (node.type === "Literal" && typeof node.value === "string") ||
+            node.type === "TemplateLiteral"
+        );
+    },
+
+    /**
+     * Checks whether a given node is a breakable statement or not.
+     * The node is breakable if the node is one of the following type:
+     *
+     * - DoWhileStatement
+     * - ForInStatement
+     * - ForOfStatement
+     * - ForStatement
+     * - SwitchStatement
+     * - WhileStatement
+     *
+     * @param {ASTNode} node - A node to check.
+     * @returns {boolean} `true` if the node is breakable.
+     */
+    isBreakableStatement(node) {
+        return breakableTypePattern.test(node.type);
+    },
+
+    /**
+     * Gets the label if the parent node of a given node is a LabeledStatement.
+     *
+     * @param {ASTNode} node - A node to get.
+     * @returns {string|null} The label or `null`.
+     */
+    getLabel(node) {
+        if (node.parent.type === "LabeledStatement") {
+            return node.parent.label.name;
+        }
+        return null;
+    },
+
+    /**
+     * Gets references which are non initializer and writable.
+     * @param {Reference[]} references - An array of references.
+     * @returns {Reference[]} An array of only references which are non initializer and writable.
+     * @public
+     */
+    getModifyingReferences(references) {
+        return references.filter(isModifyingReference);
+    },
+
+    /**
+     * Validate that a string passed in is surrounded by the specified character
+     * @param  {string} val The text to check.
+     * @param  {string} character The character to see if it's surrounded by.
+     * @returns {boolean} True if the text is surrounded by the character, false if not.
+     * @private
+     */
+    isSurroundedBy(val, character) {
+        return val[0] === character && val[val.length - 1] === character;
+    },
+
+    /**
+     * Returns whether the provided node is an ESLint directive comment or not
+     * @param {LineComment|BlockComment} node The node to be checked
+     * @returns {boolean} `true` if the node is an ESLint directive comment
+     */
+    isDirectiveComment(node) {
+        const comment = node.value.trim();
+
+        return (
+            node.type === "Line" && comment.indexOf("eslint-") === 0 ||
+            node.type === "Block" && (
+                comment.indexOf("global ") === 0 ||
+                comment.indexOf("eslint ") === 0 ||
+                comment.indexOf("eslint-") === 0
+            )
+        );
+    },
+
+    /**
+     * Gets the trailing statement of a given node.
+     *
+     *     if (code)
+     *         consequent;
+     *
+     * When taking this `IfStatement`, returns `consequent;` statement.
+     *
+     * @param {ASTNode} A node to get.
+     * @returns {ASTNode|null} The trailing statement's node.
+     */
+    getTrailingStatement: esutils.ast.trailingStatement,
+
+    /**
+     * Finds the variable by a given name in a given scope and its upper scopes.
+     *
+     * @param {escope.Scope} initScope - A scope to start find.
+     * @param {string} name - A variable name to find.
+     * @returns {escope.Variable|null} A found variable or `null`.
+     */
+    getVariableByName(initScope, name) {
+        let scope = initScope;
+
+        while (scope) {
+            const variable = scope.set.get(name);
+
+            if (variable) {
+                return variable;
+            }
+
+            scope = scope.upper;
+        }
+
+        return null;
+    },
+
+    /**
+     * Checks whether or not a given function node is the default `this` binding.
+     *
+     * First, this checks the node:
+     *
+     * - The function name does not start with uppercase (it's a constructor).
+     * - The function does not have a JSDoc comment that has a @this tag.
+     *
+     * Next, this checks the location of the node.
+     * If the location is below, this judges `this` is valid.
+     *
+     * - The location is not on an object literal.
+     * - The location is not assigned to a variable which starts with an uppercase letter.
+     * - The location is not on an ES2015 class.
+     * - Its `bind`/`call`/`apply` method is not called directly.
+     * - The function is not a callback of array methods (such as `.forEach()`) if `thisArg` is given.
+     *
+     * @param {ASTNode} node - A function node to check.
+     * @param {SourceCode} sourceCode - A SourceCode instance to get comments.
+     * @returns {boolean} The function node is the default `this` binding.
+     */
+    isDefaultThisBinding(node, sourceCode) {
+        if (isES5Constructor(node) || hasJSDocThisTag(node, sourceCode)) {
+            return false;
+        }
+        const isAnonymous = node.id === null;
+
+        while (node) {
+            const parent = node.parent;
+
+            switch (parent.type) {
+
+                /*
+                 * Looks up the destination.
+                 * e.g., obj.foo = nativeFoo || function foo() { ... };
+                 */
+                case "LogicalExpression":
+                case "ConditionalExpression":
+                    node = parent;
+                    break;
+
+                // If the upper function is IIFE, checks the destination of the return value.
+                // e.g.
+                //   obj.foo = (function() {
+                //     // setup...
+                //     return function foo() { ... };
+                //   })();
+                case "ReturnStatement": {
+                    const func = getUpperFunction(parent);
+
+                    if (func === null || !isCallee(func)) {
+                        return true;
+                    }
+                    node = func.parent;
+                    break;
+                }
+
+                // e.g.
+                //   var obj = { foo() { ... } };
+                //   var obj = { foo: function() { ... } };
+                //   class A { constructor() { ... } }
+                //   class A { foo() { ... } }
+                //   class A { get foo() { ... } }
+                //   class A { set foo() { ... } }
+                //   class A { static foo() { ... } }
+                case "Property":
+                case "MethodDefinition":
+                    return parent.value !== node;
+
+                // e.g.
+                //   obj.foo = function foo() { ... };
+                //   Foo = function() { ... };
+                //   [obj.foo = function foo() { ... }] = a;
+                //   [Foo = function() { ... }] = a;
+                case "AssignmentExpression":
+                case "AssignmentPattern":
+                    if (parent.right === node) {
+                        if (parent.left.type === "MemberExpression") {
+                            return false;
+                        }
+                        if (isAnonymous &&
+                            parent.left.type === "Identifier" &&
+                            startsWithUpperCase(parent.left.name)
+                        ) {
+                            return false;
+                        }
+                    }
+                    return true;
+
+                // e.g.
+                //   var Foo = function() { ... };
+                case "VariableDeclarator":
+                    return !(
+                        isAnonymous &&
+                        parent.init === node &&
+                        parent.id.type === "Identifier" &&
+                        startsWithUpperCase(parent.id.name)
+                    );
+
+                // e.g.
+                //   var foo = function foo() { ... }.bind(obj);
+                //   (function foo() { ... }).call(obj);
+                //   (function foo() { ... }).apply(obj, []);
+                case "MemberExpression":
+                    return (
+                        parent.object !== node ||
+                        parent.property.type !== "Identifier" ||
+                        !bindOrCallOrApplyPattern.test(parent.property.name) ||
+                        !isCallee(parent) ||
+                        parent.parent.arguments.length === 0 ||
+                        isNullOrUndefined(parent.parent.arguments[0])
+                    );
+
+                // e.g.
+                //   Reflect.apply(function() {}, obj, []);
+                //   Array.from([], function() {}, obj);
+                //   list.forEach(function() {}, obj);
+                case "CallExpression":
+                    if (isReflectApply(parent.callee)) {
+                        return (
+                            parent.arguments.length !== 3 ||
+                            parent.arguments[0] !== node ||
+                            isNullOrUndefined(parent.arguments[1])
+                        );
+                    }
+                    if (isArrayFromMethod(parent.callee)) {
+                        return (
+                            parent.arguments.length !== 3 ||
+                            parent.arguments[1] !== node ||
+                            isNullOrUndefined(parent.arguments[2])
+                        );
+                    }
+                    if (isMethodWhichHasThisArg(parent.callee)) {
+                        return (
+                            parent.arguments.length !== 2 ||
+                            parent.arguments[0] !== node ||
+                            isNullOrUndefined(parent.arguments[1])
+                        );
+                    }
+                    return true;
+
+                // Otherwise `this` is default.
+                default:
+                    return true;
+            }
+        }
+
+        /* istanbul ignore next */
+        return true;
+    },
+
+    /**
+     * Get the precedence level based on the node type
+     * @param {ASTNode} node node to evaluate
+     * @returns {int} precedence level
+     * @private
+     */
+    getPrecedence(node) {
+        switch (node.type) {
+            case "SequenceExpression":
+                return 0;
+
+            case "AssignmentExpression":
+            case "ArrowFunctionExpression":
+            case "YieldExpression":
+                return 1;
+
+            case "ConditionalExpression":
+                return 3;
+
+            case "LogicalExpression":
+                switch (node.operator) {
+                    case "||":
+                        return 4;
+                    case "&&":
+                        return 5;
+
+                    // no default
+                }
+
+                /* falls through */
+
+            case "BinaryExpression":
+
+                switch (node.operator) {
+                    case "|":
+                        return 6;
+                    case "^":
+                        return 7;
+                    case "&":
+                        return 8;
+                    case "==":
+                    case "!=":
+                    case "===":
+                    case "!==":
+                        return 9;
+                    case "<":
+                    case "<=":
+                    case ">":
+                    case ">=":
+                    case "in":
+                    case "instanceof":
+                        return 10;
+                    case "<<":
+                    case ">>":
+                    case ">>>":
+                        return 11;
+                    case "+":
+                    case "-":
+                        return 12;
+                    case "*":
+                    case "/":
+                    case "%":
+                        return 13;
+
+                    // no default
+                }
+
+                /* falls through */
+
+            case "UnaryExpression":
+            case "AwaitExpression":
+                return 14;
+
+            case "UpdateExpression":
+                return 15;
+
+            case "CallExpression":
+
+                // IIFE is allowed to have parens in any position (#655)
+                if (node.callee.type === "FunctionExpression") {
+                    return -1;
+                }
+                return 16;
+
+            case "NewExpression":
+                return 17;
+
+            // no default
+        }
+        return 18;
+    },
+
+    /**
+     * Checks whether a given node is a loop node or not.
+     * The following types are loop nodes:
+     *
+     * - DoWhileStatement
+     * - ForInStatement
+     * - ForOfStatement
+     * - ForStatement
+     * - WhileStatement
+     *
+     * @param {ASTNode|null} node - A node to check.
+     * @returns {boolean} `true` if the node is a loop node.
+     */
+    isLoop(node) {
+        return Boolean(node && anyLoopPattern.test(node.type));
+    },
+
+    /**
+     * Checks whether a given node is a function node or not.
+     * The following types are function nodes:
+     *
+     * - ArrowFunctionExpression
+     * - FunctionDeclaration
+     * - FunctionExpression
+     *
+     * @param {ASTNode|null} node - A node to check.
+     * @returns {boolean} `true` if the node is a function node.
+     */
+    isFunction(node) {
+        return Boolean(node && anyFunctionPattern.test(node.type));
+    },
+
+    /**
+     * Gets the property name of a given node.
+     * The node can be a MemberExpression, a Property, or a MethodDefinition.
+     *
+     * If the name is dynamic, this returns `null`.
+     *
+     * For examples:
+     *
+     *     a.b           // => "b"
+     *     a["b"]        // => "b"
+     *     a['b']        // => "b"
+     *     a[`b`]        // => "b"
+     *     a[100]        // => "100"
+     *     a[b]          // => null
+     *     a["a" + "b"]  // => null
+     *     a[tag`b`]     // => null
+     *     a[`${b}`]     // => null
+     *
+     *     let a = {b: 1}            // => "b"
+     *     let a = {["b"]: 1}        // => "b"
+     *     let a = {['b']: 1}        // => "b"
+     *     let a = {[`b`]: 1}        // => "b"
+     *     let a = {[100]: 1}        // => "100"
+     *     let a = {[b]: 1}          // => null
+     *     let a = {["a" + "b"]: 1}  // => null
+     *     let a = {[tag`b`]: 1}     // => null
+     *     let a = {[`${b}`]: 1}     // => null
+     *
+     * @param {ASTNode} node - The node to get.
+     * @returns {string|null} The property name if static. Otherwise, null.
+     */
+    getStaticPropertyName(node) {
+        let prop;
+
+        switch (node && node.type) {
+            case "Property":
+            case "MethodDefinition":
+                prop = node.key;
+                break;
+
+            case "MemberExpression":
+                prop = node.property;
+                break;
+
+            // no default
+        }
+
+        switch (prop && prop.type) {
+            case "Literal":
+                return String(prop.value);
+
+            case "TemplateLiteral":
+                if (prop.expressions.length === 0 && prop.quasis.length === 1) {
+                    return prop.quasis[0].value.cooked;
+                }
+                break;
+
+            case "Identifier":
+                if (!node.computed) {
+                    return prop.name;
+                }
+                break;
+
+            // no default
+        }
+
+        return null;
+    },
+
+    /**
+     * Get directives from directive prologue of a Program or Function node.
+     * @param {ASTNode} node - The node to check.
+     * @returns {ASTNode[]} The directives found in the directive prologue.
+     */
+    getDirectivePrologue(node) {
+        const directives = [];
+
+        // Directive prologues only occur at the top of files or functions.
+        if (
+            node.type === "Program" ||
+            node.type === "FunctionDeclaration" ||
+            node.type === "FunctionExpression" ||
+
+            // Do not check arrow functions with implicit return.
+            // `() => "use strict";` returns the string `"use strict"`.
+            (node.type === "ArrowFunctionExpression" && node.body.type === "BlockStatement")
+        ) {
+            const statements = node.type === "Program" ? node.body : node.body.body;
+
+            for (const statement of statements) {
+                if (
+                    statement.type === "ExpressionStatement" &&
+                    statement.expression.type === "Literal"
+                ) {
+                    directives.push(statement);
+                } else {
+                    break;
+                }
+            }
+        }
+
+        return directives;
+    },
+
+
+    /**
+     * Determines whether this node is a decimal integer literal. If a node is a decimal integer literal, a dot added
+     after the node will be parsed as a decimal point, rather than a property-access dot.
+     * @param {ASTNode} node - The node to check.
+     * @returns {boolean} `true` if this node is a decimal integer.
+     * @example
+     *
+     * 5       // true
+     * 5.      // false
+     * 5.0     // false
+     * 05      // false
+     * 0x5     // false
+     * 0b101   // false
+     * 0o5     // false
+     * 5e0     // false
+     * '5'     // false
+     */
+    isDecimalInteger(node) {
+        return node.type === "Literal" && typeof node.value === "number" && /^(0|[1-9]\d*)$/.test(node.raw);
+    }
+};

--- a/ast-utils.js
+++ b/ast-utils.js
@@ -9,8 +9,6 @@
 // Requirements
 //------------------------------------------------------------------------------
 
-const esutils = require("esutils");
-
 //------------------------------------------------------------------------------
 // Helpers
 //------------------------------------------------------------------------------
@@ -302,19 +300,6 @@ module.exports = {
             )
         );
     },
-
-    /**
-     * Gets the trailing statement of a given node.
-     *
-     *     if (code)
-     *         consequent;
-     *
-     * When taking this `IfStatement`, returns `consequent;` statement.
-     *
-     * @param {ASTNode} A node to get.
-     * @returns {ASTNode|null} The trailing statement's node.
-     */
-    getTrailingStatement: esutils.ast.trailingStatement,
 
     /**
      * Finds the variable by a given name in a given scope and its upper scopes.

--- a/index.js
+++ b/index.js
@@ -11,6 +11,7 @@ module.exports = {
     'no-await-in-loop': require('./rules/no-await-in-loop'),
     'flow-object-type': require('./rules/flow-object-type'),
     'func-params-comma-dangle': require('./rules/func-params-comma-dangle'),
+    'no-invalid-this': require('./rules/no-invalid-this'),
   },
   rulesConfig: {
     'generator-star-spacing': 0,
@@ -22,5 +23,6 @@ module.exports = {
     'no-await-in-loop': 0,
     'flow-object-type': 0,
     'func-params-comma-dangle': 0,
+    'no-invalid-this': 0,
   }
 };

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   "devDependencies": {
     "babel-eslint": "^6.1.0",
     "eslint": "^3.0.0",
+    "lodash.clonedeep": "^4.5.0",
     "mocha": "^3.0.0"
   }
 }

--- a/rules/no-invalid-this.js
+++ b/rules/no-invalid-this.js
@@ -1,0 +1,122 @@
+/**
+ * @fileoverview A rule to disallow `this` keywords outside of classes or class-like objects.
+ * @author Toru Nagashima
+ */
+
+"use strict";
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+const astUtils = require("../ast-utils");
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+module.exports = {
+    meta: {
+        docs: {
+            description: "disallow `this` keywords outside of classes or class-like objects",
+            category: "Best Practices",
+            recommended: false
+        },
+
+        schema: []
+    },
+
+    create(context) {
+        const stack = [],
+            sourceCode = context.getSourceCode();
+
+        /**
+         * Gets the current checking context.
+         *
+         * The return value has a flag that whether or not `this` keyword is valid.
+         * The flag is initialized when got at the first time.
+         *
+         * @returns {{valid: boolean}}
+         *   an object which has a flag that whether or not `this` keyword is valid.
+         */
+        stack.getCurrent = function() {
+            const current = this[this.length - 1];
+
+            if (!current.init) {
+                current.init = true;
+                current.valid = !astUtils.isDefaultThisBinding(
+                    current.node,
+                    sourceCode);
+            }
+            return current;
+        };
+
+        /**
+         * Pushs new checking context into the stack.
+         *
+         * The checking context is not initialized yet.
+         * Because most functions don't have `this` keyword.
+         * When `this` keyword was found, the checking context is initialized.
+         *
+         * @param {ASTNode} node - A function node that was entered.
+         * @returns {void}
+         */
+        function enterFunction(node) {
+
+            // `this` can be invalid only under strict mode.
+            stack.push({
+                init: !context.getScope().isStrict,
+                node,
+                valid: true
+            });
+        }
+
+        /**
+         * Pops the current checking context from the stack.
+         * @returns {void}
+         */
+        function exitFunction() {
+            stack.pop();
+        }
+
+        return {
+
+            /*
+             * `this` is invalid only under strict mode.
+             * Modules is always strict mode.
+             */
+            Program(node) {
+                const scope = context.getScope(),
+                    features = context.parserOptions.ecmaFeatures || {};
+
+                stack.push({
+                    init: true,
+                    node,
+                    valid: !(
+                        scope.isStrict ||
+                        node.sourceType === "module" ||
+                        (features.globalReturn && scope.childScopes[0].isStrict)
+                    )
+                });
+            },
+
+            "Program:exit"() {
+                stack.pop();
+            },
+
+            FunctionDeclaration: enterFunction,
+            "FunctionDeclaration:exit": exitFunction,
+            FunctionExpression: enterFunction,
+            "FunctionExpression:exit": exitFunction,
+
+            // Reports if `this` of the current context is invalid.
+            ThisExpression(node) {
+                const current = stack.getCurrent();
+
+                if (current && !current.valid) {
+                    context.report(node, "Unexpected 'this'.");
+                }
+            }
+        };
+    }
+};

--- a/tests/rules/no-invalid-this.js
+++ b/tests/rules/no-invalid-this.js
@@ -9,7 +9,7 @@
 // Requirements
 //------------------------------------------------------------------------------
 
-const lodash = require("lodash");
+const cloneDeep = require("lodash.clonedeep");
 const rule = require("../../rules/no-invalid-this");
 const RuleTester = require("../RuleTester");
 
@@ -68,7 +68,7 @@ function extractPatterns(patterns, type) {
     // Clone and apply the pattern environment.
     const patternsList = patterns.map(function(pattern) {
         return pattern[type].map(function(applyCondition) {
-            const thisPattern = lodash.cloneDeep(pattern);
+            const thisPattern = cloneDeep(pattern);
 
             applyCondition(thisPattern);
 
@@ -581,6 +581,23 @@ const patterns = [
         errors,
         valid: [NORMAL],
         invalid: [USE_STRICT, IMPLIED_STRICT, MODULES]
+    },
+
+    // babel/no-invalid-this
+
+    // Class Instance Properties.
+    {
+        code: "class A {a = this.b;};",
+        parserOptions: { ecmaVersion: 6 },
+        valid: [NORMAL, USE_STRICT, IMPLIED_STRICT, MODULES],
+        invalid: []
+    },
+
+    {
+        code: "class A {a = () => {return this.b;};};",
+        parserOptions: { ecmaVersion: 6 },
+        valid: [NORMAL, USE_STRICT, IMPLIED_STRICT, MODULES],
+        invalid: []
     },
 ];
 

--- a/tests/rules/no-invalid-this.js
+++ b/tests/rules/no-invalid-this.js
@@ -1,0 +1,592 @@
+/**
+ * @fileoverview Tests for no-invalid-this rule.
+ * @author Toru Nagashima
+ */
+
+"use strict";
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+const lodash = require("lodash");
+const rule = require("../../rules/no-invalid-this");
+const RuleTester = require("../RuleTester");
+
+//------------------------------------------------------------------------------
+// Helpers
+//------------------------------------------------------------------------------
+
+/**
+ * A constant value for non strict mode environment.
+ * @returns {void}
+ */
+function NORMAL(pattern) {
+    pattern.parserOptions.sourceType = "script";
+}
+
+/**
+ * A constant value for strict mode environment.
+ * This modifies pattern object to make strict mode.
+ * @param {Object} pattern - A pattern object to modify.
+ * @returns {void}
+ */
+function USE_STRICT(pattern) {
+    pattern.code = "\"use strict\"; " + pattern.code;
+}
+
+/**
+ * A constant value for implied strict mode.
+ * This modifies pattern object to impose strict mode.
+ * @param {Object} pattern - A pattern object to modify.
+ * @returns {void}
+ */
+function IMPLIED_STRICT(pattern) {
+    pattern.code = "/* implied strict mode */ " + pattern.code;
+    pattern.parserOptions.ecmaFeatures = pattern.parserOptions.ecmaFeatures || {};
+    pattern.parserOptions.ecmaFeatures.impliedStrict = true;
+}
+
+/**
+ * A constant value for modules environment.
+ * This modifies pattern object to make modules.
+ * @param {Object} pattern - A pattern object to modify.
+ * @returns {void}
+ */
+function MODULES(pattern) {
+    pattern.code = "/* modules */ " + pattern.code;
+}
+
+/**
+ * Extracts patterns each condition for a specified type. The type is `valid` or `invalid`.
+ * @param {Object[]} patterns - Original patterns.
+ * @param {string} type - One of `"valid"` or `"invalid"`.
+ * @returns {Object[]} Test patterns.
+ */
+function extractPatterns(patterns, type) {
+
+    // Clone and apply the pattern environment.
+    const patternsList = patterns.map(function(pattern) {
+        return pattern[type].map(function(applyCondition) {
+            const thisPattern = lodash.cloneDeep(pattern);
+
+            applyCondition(thisPattern);
+
+            if (type === "valid") {
+                thisPattern.errors = [];
+            } else {
+                thisPattern.code += " /* should error */";
+            }
+
+            return thisPattern;
+        });
+    });
+
+    // Flatten.
+    return Array.prototype.concat.apply([], patternsList);
+}
+
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+const errors = [
+    {message: "Unexpected 'this'.", type: "ThisExpression"},
+    {message: "Unexpected 'this'.", type: "ThisExpression"}
+];
+
+const patterns = [
+
+    // Global.
+    {
+        code: "console.log(this); z(x => console.log(x, this));",
+        parserOptions: { ecmaVersion: 6 },
+        errors,
+        valid: [NORMAL],
+        invalid: [USE_STRICT, IMPLIED_STRICT, MODULES]
+    },
+    {
+        code: "console.log(this); z(x => console.log(x, this));",
+        parserOptions: {
+            ecmaVersion: 6,
+            ecmaFeatures: {globalReturn: true}
+        },
+        errors,
+        valid: [NORMAL],
+        invalid: [USE_STRICT, IMPLIED_STRICT, MODULES]
+    },
+
+    // IIFE.
+    {
+        code: "(function() { console.log(this); z(x => console.log(x, this)); })();",
+        parserOptions: { ecmaVersion: 6 },
+        errors,
+        valid: [NORMAL],
+        invalid: [USE_STRICT, IMPLIED_STRICT, MODULES]
+    },
+
+    // Just functions.
+    {
+        code: "function foo() { console.log(this); z(x => console.log(x, this)); }",
+        parserOptions: { ecmaVersion: 6 },
+        errors,
+        valid: [NORMAL],
+        invalid: [USE_STRICT, IMPLIED_STRICT, MODULES]
+    },
+    {
+        code: "function foo() { \"use strict\"; console.log(this); z(x => console.log(x, this)); }",
+        parserOptions: { ecmaVersion: 6 },
+        errors,
+        valid: [],
+        invalid: [NORMAL, USE_STRICT, IMPLIED_STRICT, MODULES]
+    },
+    {
+        code: "return function() { console.log(this); z(x => console.log(x, this)); };",
+        parserOptions: {
+            ecmaVersion: 6,
+            ecmaFeatures: {globalReturn: true}
+        },
+        errors,
+        valid: [NORMAL],
+        invalid: [USE_STRICT, IMPLIED_STRICT] // modules cannot return on global.
+    },
+    {
+        code: "var foo = (function() { console.log(this); z(x => console.log(x, this)); }).bar(obj);",
+        parserOptions: { ecmaVersion: 6 },
+        errors,
+        valid: [NORMAL],
+        invalid: [USE_STRICT, IMPLIED_STRICT, MODULES]
+    },
+
+    // Functions in methods.
+    {
+        code: "var obj = {foo: function() { function foo() { console.log(this); z(x => console.log(x, this)); } foo(); }};",
+        parserOptions: { ecmaVersion: 6 },
+        errors,
+        valid: [NORMAL],
+        invalid: [USE_STRICT, IMPLIED_STRICT, MODULES]
+    },
+    {
+        code: "var obj = {foo() { function foo() { console.log(this); z(x => console.log(x, this)); } foo(); }};",
+        parserOptions: { ecmaVersion: 6 },
+        errors,
+        valid: [NORMAL],
+        invalid: [USE_STRICT, IMPLIED_STRICT, MODULES]
+    },
+    {
+        code: "var obj = {foo: function() { return function() { console.log(this); z(x => console.log(x, this)); }; }};",
+        parserOptions: { ecmaVersion: 6 },
+        errors,
+        valid: [NORMAL],
+        invalid: [USE_STRICT, IMPLIED_STRICT, MODULES]
+    },
+    {
+        code: "var obj = {foo: function() { \"use strict\"; return function() { console.log(this); z(x => console.log(x, this)); }; }};",
+        parserOptions: { ecmaVersion: 6 },
+        errors,
+        valid: [],
+        invalid: [NORMAL, USE_STRICT, IMPLIED_STRICT, MODULES]
+    },
+    {
+        code: "obj.foo = function() { return function() { console.log(this); z(x => console.log(x, this)); }; };",
+        parserOptions: { ecmaVersion: 6 },
+        errors,
+        valid: [NORMAL],
+        invalid: [USE_STRICT, IMPLIED_STRICT, MODULES]
+    },
+    {
+        code: "obj.foo = function() { \"use strict\"; return function() { console.log(this); z(x => console.log(x, this)); }; };",
+        parserOptions: { ecmaVersion: 6 },
+        errors,
+        valid: [],
+        invalid: [NORMAL, USE_STRICT, IMPLIED_STRICT, MODULES]
+    },
+    {
+        code: "class A { foo() { return function() { console.log(this); z(x => console.log(x, this)); }; } }",
+        parserOptions: { ecmaVersion: 6 },
+        errors,
+        valid: [],
+        invalid: [NORMAL, USE_STRICT, IMPLIED_STRICT, MODULES]
+    },
+
+    // Class Static methods.
+    {
+        code: "class A {static foo() { console.log(this); z(x => console.log(x, this)); }};",
+        parserOptions: { ecmaVersion: 6 },
+        errors,
+        valid: [NORMAL, USE_STRICT, IMPLIED_STRICT, MODULES],
+        invalid: []
+    },
+
+    // Constructors.
+    {
+        code: "function Foo() { console.log(this); z(x => console.log(x, this)); }",
+        parserOptions: { ecmaVersion: 6 },
+        valid: [NORMAL, USE_STRICT, IMPLIED_STRICT, MODULES],
+        invalid: []
+    },
+    {
+        code: "var Foo = function Foo() { console.log(this); z(x => console.log(x, this)); };",
+        parserOptions: { ecmaVersion: 6 },
+        valid: [NORMAL, USE_STRICT, IMPLIED_STRICT, MODULES],
+        invalid: []
+    },
+    {
+        code: "class A {constructor() { console.log(this); z(x => console.log(x, this)); }};",
+        parserOptions: { ecmaVersion: 6 },
+        valid: [NORMAL, USE_STRICT, IMPLIED_STRICT, MODULES],
+        invalid: []
+    },
+
+    // On a property.
+    {
+        code: "var obj = {foo: function() { console.log(this); z(x => console.log(x, this)); }};",
+        parserOptions: { ecmaVersion: 6 },
+        valid: [NORMAL, USE_STRICT, IMPLIED_STRICT, MODULES],
+        invalid: []
+    },
+    {
+        code: "var obj = {foo() { console.log(this); z(x => console.log(x, this)); }};",
+        parserOptions: { ecmaVersion: 6 },
+        valid: [NORMAL, USE_STRICT, IMPLIED_STRICT, MODULES],
+        invalid: []
+    },
+    {
+        code: "var obj = {foo: foo || function() { console.log(this); z(x => console.log(x, this)); }};",
+        parserOptions: { ecmaVersion: 6 },
+        valid: [NORMAL, USE_STRICT, IMPLIED_STRICT, MODULES],
+        invalid: []
+    },
+    {
+        code: "var obj = {foo: hasNative ? foo : function() { console.log(this); z(x => console.log(x, this)); }};",
+        parserOptions: { ecmaVersion: 6 },
+        valid: [NORMAL, USE_STRICT, IMPLIED_STRICT, MODULES],
+        invalid: []
+    },
+    {
+        code: "var obj = {foo: (function() { return function() { console.log(this); z(x => console.log(x, this)); }; })()};",
+        parserOptions: { ecmaVersion: 6 },
+        valid: [NORMAL, USE_STRICT, IMPLIED_STRICT, MODULES],
+        invalid: []
+    },
+    {
+        code: "Object.defineProperty(obj, \"foo\", {value: function() { console.log(this); z(x => console.log(x, this)); }})",
+        parserOptions: { ecmaVersion: 6 },
+        valid: [NORMAL, USE_STRICT, IMPLIED_STRICT, MODULES],
+        invalid: []
+    },
+    {
+        code: "Object.defineProperties(obj, {foo: {value: function() { console.log(this); z(x => console.log(x, this)); }}})",
+        parserOptions: { ecmaVersion: 6 },
+        valid: [NORMAL, USE_STRICT, IMPLIED_STRICT, MODULES],
+        invalid: []
+    },
+
+    // Assigns to a property.
+    {
+        code: "obj.foo = function() { console.log(this); z(x => console.log(x, this)); };",
+        parserOptions: { ecmaVersion: 6 },
+        valid: [NORMAL, USE_STRICT, IMPLIED_STRICT, MODULES],
+        invalid: []
+    },
+    {
+        code: "obj.foo = foo || function() { console.log(this); z(x => console.log(x, this)); };",
+        parserOptions: { ecmaVersion: 6 },
+        valid: [NORMAL, USE_STRICT, IMPLIED_STRICT, MODULES],
+        invalid: []
+    },
+    {
+        code: "obj.foo = foo ? bar : function() { console.log(this); z(x => console.log(x, this)); };",
+        parserOptions: { ecmaVersion: 6 },
+        valid: [NORMAL, USE_STRICT, IMPLIED_STRICT, MODULES],
+        invalid: []
+    },
+    {
+        code: "obj.foo = (function() { return function() { console.log(this); z(x => console.log(x, this)); }; })();",
+        parserOptions: { ecmaVersion: 6 },
+        valid: [NORMAL, USE_STRICT, IMPLIED_STRICT, MODULES],
+        invalid: []
+    },
+
+    // Class Instance Methods.
+    {
+        code: "class A {foo() { console.log(this); z(x => console.log(x, this)); }};",
+        parserOptions: { ecmaVersion: 6 },
+        valid: [NORMAL, USE_STRICT, IMPLIED_STRICT, MODULES],
+        invalid: []
+    },
+
+    // Bind/Call/Apply
+    {
+        code: "var foo = function() { console.log(this); z(x => console.log(x, this)); }.bind(obj);",
+        parserOptions: { ecmaVersion: 6 },
+        valid: [NORMAL, USE_STRICT, IMPLIED_STRICT, MODULES],
+        invalid: []
+    },
+    {
+        code: "var foo = function() { console.log(this); z(x => console.log(x, this)); }.bind(null);",
+        parserOptions: { ecmaVersion: 6 },
+        errors,
+        valid: [NORMAL],
+        invalid: [USE_STRICT, IMPLIED_STRICT, MODULES]
+    },
+    {
+        code: "(function() { console.log(this); z(x => console.log(x, this)); }).call(obj);",
+        parserOptions: { ecmaVersion: 6 },
+        valid: [NORMAL, USE_STRICT, IMPLIED_STRICT, MODULES],
+        invalid: []
+    },
+    {
+        code: "(function() { console.log(this); z(x => console.log(x, this)); }).call(undefined);",
+        parserOptions: { ecmaVersion: 6 },
+        errors,
+        valid: [NORMAL],
+        invalid: [USE_STRICT, IMPLIED_STRICT, MODULES]
+    },
+    {
+        code: "(function() { console.log(this); z(x => console.log(x, this)); }).apply(obj);",
+        parserOptions: { ecmaVersion: 6 },
+        valid: [NORMAL, USE_STRICT, IMPLIED_STRICT, MODULES],
+        invalid: []
+    },
+    {
+        code: "(function() { console.log(this); z(x => console.log(x, this)); }).apply(void 0);",
+        parserOptions: { ecmaVersion: 6 },
+        errors,
+        valid: [NORMAL],
+        invalid: [USE_STRICT, IMPLIED_STRICT, MODULES]
+    },
+    {
+        code: "Reflect.apply(function() { console.log(this); z(x => console.log(x, this)); }, obj, []);",
+        parserOptions: { ecmaVersion: 6 },
+        valid: [NORMAL, USE_STRICT, IMPLIED_STRICT, MODULES],
+        invalid: []
+    },
+
+    // Array methods.
+    {
+        code: "Array.from([], function() { console.log(this); z(x => console.log(x, this)); });",
+        parserOptions: { ecmaVersion: 6 },
+        errors,
+        valid: [NORMAL],
+        invalid: [USE_STRICT, IMPLIED_STRICT, MODULES]
+    },
+    {
+        code: "foo.every(function() { console.log(this); z(x => console.log(x, this)); });",
+        parserOptions: { ecmaVersion: 6 },
+        errors,
+        valid: [NORMAL],
+        invalid: [USE_STRICT, IMPLIED_STRICT, MODULES]
+    },
+    {
+        code: "foo.filter(function() { console.log(this); z(x => console.log(x, this)); });",
+        parserOptions: { ecmaVersion: 6 },
+        errors,
+        valid: [NORMAL],
+        invalid: [USE_STRICT, IMPLIED_STRICT, MODULES]
+    },
+    {
+        code: "foo.find(function() { console.log(this); z(x => console.log(x, this)); });",
+        parserOptions: { ecmaVersion: 6 },
+        errors,
+        valid: [NORMAL],
+        invalid: [USE_STRICT, IMPLIED_STRICT, MODULES]
+    },
+    {
+        code: "foo.findIndex(function() { console.log(this); z(x => console.log(x, this)); });",
+        parserOptions: { ecmaVersion: 6 },
+        errors,
+        valid: [NORMAL],
+        invalid: [USE_STRICT, IMPLIED_STRICT, MODULES]
+    },
+    {
+        code: "foo.forEach(function() { console.log(this); z(x => console.log(x, this)); });",
+        parserOptions: { ecmaVersion: 6 },
+        errors,
+        valid: [NORMAL],
+        invalid: [USE_STRICT, IMPLIED_STRICT, MODULES]
+    },
+    {
+        code: "foo.map(function() { console.log(this); z(x => console.log(x, this)); });",
+        parserOptions: { ecmaVersion: 6 },
+        errors,
+        valid: [NORMAL],
+        invalid: [USE_STRICT, IMPLIED_STRICT, MODULES]
+    },
+    {
+        code: "foo.some(function() { console.log(this); z(x => console.log(x, this)); });",
+        parserOptions: { ecmaVersion: 6 },
+        errors,
+        valid: [NORMAL],
+        invalid: [USE_STRICT, IMPLIED_STRICT, MODULES]
+    },
+    {
+        code: "Array.from([], function() { console.log(this); z(x => console.log(x, this)); }, obj);",
+        parserOptions: { ecmaVersion: 6 },
+        valid: [NORMAL, USE_STRICT, IMPLIED_STRICT, MODULES],
+        invalid: []
+    },
+    {
+        code: "foo.every(function() { console.log(this); z(x => console.log(x, this)); }, obj);",
+        parserOptions: { ecmaVersion: 6 },
+        valid: [NORMAL, USE_STRICT, IMPLIED_STRICT, MODULES],
+        invalid: []
+    },
+    {
+        code: "foo.filter(function() { console.log(this); z(x => console.log(x, this)); }, obj);",
+        parserOptions: { ecmaVersion: 6 },
+        valid: [NORMAL, USE_STRICT, IMPLIED_STRICT, MODULES],
+        invalid: []
+    },
+    {
+        code: "foo.find(function() { console.log(this); z(x => console.log(x, this)); }, obj);",
+        parserOptions: { ecmaVersion: 6 },
+        valid: [NORMAL, USE_STRICT, IMPLIED_STRICT, MODULES],
+        invalid: []
+    },
+    {
+        code: "foo.findIndex(function() { console.log(this); z(x => console.log(x, this)); }, obj);",
+        parserOptions: { ecmaVersion: 6 },
+        valid: [NORMAL, USE_STRICT, IMPLIED_STRICT, MODULES],
+        invalid: []
+    },
+    {
+        code: "foo.forEach(function() { console.log(this); z(x => console.log(x, this)); }, obj);",
+        parserOptions: { ecmaVersion: 6 },
+        valid: [NORMAL, USE_STRICT, IMPLIED_STRICT, MODULES],
+        invalid: []
+    },
+    {
+        code: "foo.map(function() { console.log(this); z(x => console.log(x, this)); }, obj);",
+        parserOptions: { ecmaVersion: 6 },
+        valid: [NORMAL, USE_STRICT, IMPLIED_STRICT, MODULES],
+        invalid: []
+    },
+    {
+        code: "foo.some(function() { console.log(this); z(x => console.log(x, this)); }, obj);",
+        parserOptions: { ecmaVersion: 6 },
+        valid: [NORMAL, USE_STRICT, IMPLIED_STRICT, MODULES],
+        invalid: []
+    },
+    {
+        code: "foo.forEach(function() { console.log(this); z(x => console.log(x, this)); }, null);",
+        parserOptions: { ecmaVersion: 6 },
+        errors,
+        valid: [NORMAL],
+        invalid: [USE_STRICT, IMPLIED_STRICT, MODULES]
+    },
+
+    // @this tag.
+    {
+        code: "/** @this Obj */ function foo() { console.log(this); z(x => console.log(x, this)); }",
+        parserOptions: { ecmaVersion: 6 },
+        valid: [NORMAL, USE_STRICT, IMPLIED_STRICT, MODULES],
+        invalid: []
+    },
+    {
+        code: "/**\n * @returns {void}\n * @this Obj\n */\nfunction foo() { console.log(this); z(x => console.log(x, this)); }",
+        parserOptions: { ecmaVersion: 6 },
+        valid: [NORMAL, USE_STRICT, IMPLIED_STRICT, MODULES],
+        invalid: []
+    },
+    {
+        code: "/** @returns {void} */ function foo() { console.log(this); z(x => console.log(x, this)); }",
+        parserOptions: { ecmaVersion: 6 },
+        errors,
+        valid: [NORMAL],
+        invalid: [USE_STRICT, IMPLIED_STRICT, MODULES]
+    },
+    {
+        code: "/** @this Obj */ foo(function() { console.log(this); z(x => console.log(x, this)); });",
+        parserOptions: { ecmaVersion: 6 },
+        errors,
+        valid: [NORMAL],
+        invalid: [USE_STRICT, IMPLIED_STRICT, MODULES]
+    },
+    {
+        code: "foo(/* @this Obj */ function() { console.log(this); z(x => console.log(x, this)); });",
+        parserOptions: { ecmaVersion: 6 },
+        errors,
+        valid: [NORMAL, USE_STRICT, IMPLIED_STRICT, MODULES],
+        invalid: []
+    },
+
+    // https://github.com/eslint/eslint/issues/3254
+    {
+        code: "function foo() { console.log(this); z(x => console.log(x, this)); }",
+        parserOptions: { ecmaVersion: 6 },
+        errors,
+        valid: [NORMAL],
+        invalid: [USE_STRICT, IMPLIED_STRICT, MODULES]
+    },
+
+    // https://github.com/eslint/eslint/issues/3287
+    {
+        code: "function foo() { /** @this Obj*/ return function bar() { console.log(this); z(x => console.log(x, this)); }; }",
+        parserOptions: { ecmaVersion: 6 },
+        valid: [NORMAL, USE_STRICT, IMPLIED_STRICT, MODULES],
+        invalid: []
+    },
+
+    // https://github.com/eslint/eslint/issues/6824
+    {
+        code: "var Ctor = function() { console.log(this); z(x => console.log(x, this)); }",
+        parserOptions: { ecmaVersion: 6 },
+        valid: [NORMAL, USE_STRICT, IMPLIED_STRICT, MODULES],
+        invalid: []
+    },
+    {
+        code: "var func = function() { console.log(this); z(x => console.log(x, this)); }",
+        parserOptions: { ecmaVersion: 6 },
+        errors,
+        valid: [NORMAL],
+        invalid: [USE_STRICT, IMPLIED_STRICT, MODULES]
+    },
+    {
+        code: "Ctor = function() { console.log(this); z(x => console.log(x, this)); }",
+        parserOptions: { ecmaVersion: 6 },
+        valid: [NORMAL, USE_STRICT, IMPLIED_STRICT, MODULES],
+        invalid: []
+    },
+    {
+        code: "func = function() { console.log(this); z(x => console.log(x, this)); }",
+        parserOptions: { ecmaVersion: 6 },
+        errors,
+        valid: [NORMAL],
+        invalid: [USE_STRICT, IMPLIED_STRICT, MODULES]
+    },
+    {
+        code: "function foo(Ctor = function() { console.log(this); z(x => console.log(x, this)); }) {}",
+        parserOptions: { ecmaVersion: 6 },
+        valid: [NORMAL, USE_STRICT, IMPLIED_STRICT, MODULES],
+        invalid: []
+    },
+    {
+        code: "function foo(func = function() { console.log(this); z(x => console.log(x, this)); }) {}",
+        parserOptions: { ecmaVersion: 6 },
+        errors,
+        valid: [NORMAL],
+        invalid: [USE_STRICT, IMPLIED_STRICT, MODULES]
+    },
+    {
+        code: "[obj.method = function() { console.log(this); z(x => console.log(x, this)); }] = a",
+        parserOptions: { ecmaVersion: 6 },
+        valid: [NORMAL, USE_STRICT, IMPLIED_STRICT, MODULES],
+        invalid: []
+    },
+    {
+        code: "[func = function() { console.log(this); z(x => console.log(x, this)); }] = a",
+        parserOptions: { ecmaVersion: 6 },
+        errors,
+        valid: [NORMAL],
+        invalid: [USE_STRICT, IMPLIED_STRICT, MODULES]
+    },
+];
+
+const ruleTester = new RuleTester();
+
+ruleTester.run("no-invalid-this", rule, {
+    valid: extractPatterns(patterns, "valid"),
+    invalid: extractPatterns(patterns, "invalid")
+});


### PR DESCRIPTION
This is to help closes #12. The implementation is really rudimentary, whenever inside a class property it considers all `this` to be valid. I tried to think about it a bit, is there any scenario where it isn't the case?

All files are taken from ESLint since this proposal is still only stage 2, but might make its way into ESLint if it ever reaches stage 4 (hopefully!):
- https://github.com/eslint/eslint/blob/ce590e28ee4146ab04974c8f768b169538059585/lib/ast-utils.js
- https://github.com/eslint/eslint/blob/ce590e28ee4146ab04974c8f768b169538059585/lib/rules/no-invalid-this.js
- https://github.com/eslint/eslint/blob/ce590e28ee4146ab04974c8f768b169538059585/tests/lib/rules/no-invalid-this.js

Build fails on 0.10 and 0.12 because of https://github.com/babel/eslint-plugin-babel/pull/71#issuecomment-230582590 

I also added the `lodash.clonedeep` module to the dev dependencies since it was used in the original tests. Let me know if there is anything.
