### PR TITLE
Drop support of Node < 4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,6 @@ git:
 sudo: false
 language: node_js
 node_js:
-  - '0.10'
-  - '0.12'
   - '4'
   - '5'
   - '6'

--- a/package.json
+++ b/package.json
@@ -19,6 +19,9 @@
   ],
   "author": "Jason Quense @monasticpanic",
   "license": "MIT",
+  "engines": {
+    "node": ">=4"
+  },
   "bugs": {
     "url": "https://github.com/babel/eslint-plugin-babel/issues"
   },

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   },
   "homepage": "https://github.com/babel/eslint-plugin-babel#readme",
   "peerDependencies": {
-    "eslint": ">=1.0.0"
+    "eslint": ">=3.0.0"
   },
   "devDependencies": {
     "babel-eslint": "^6.1.0",


### PR DESCRIPTION
Since `eslint-plugin-babel` has `babel-eslint` which has been dropped support of Node < 4 already, this should drop as follow as [`babel-eslint`](https://github.com/babel/babel-eslint/blob/master/package.json#L33).