### PR TITLE
skip no-unused-expressions checks when inside a do expression

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,6 +12,7 @@ module.exports = {
     'flow-object-type': require('./rules/flow-object-type'),
     'func-params-comma-dangle': require('./rules/func-params-comma-dangle'),
     'no-invalid-this': require('./rules/no-invalid-this'),
+    'no-unused-expressions': require('./rules/no-unused-expressions'),
   },
   rulesConfig: {
     'generator-star-spacing': 0,
@@ -24,5 +25,6 @@ module.exports = {
     'flow-object-type': 0,
     'func-params-comma-dangle': 0,
     'no-invalid-this': 0,
+    'no-unused-expressions': 0,
   }
 };

--- a/rules/no-unused-expressions.js
+++ b/rules/no-unused-expressions.js
@@ -1,0 +1,138 @@
+/**
+ * @fileoverview Flag expressions in statement position that do not side effect
+ * @author Michael Ficarra
+ */
+"use strict";
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+module.exports = {
+    meta: {
+        docs: {
+            description: "disallow unused expressions",
+            category: "Best Practices",
+            recommended: false
+        },
+
+        schema: [
+            {
+                type: "object",
+                properties: {
+                    allowShortCircuit: {
+                        type: "boolean"
+                    },
+                    allowTernary: {
+                        type: "boolean"
+                    },
+                    allowDoExpression: {
+                        type: "boolean"
+                    },
+                },
+                additionalProperties: false
+            }
+        ]
+    },
+
+    create(context) {
+        const config = context.options[0] || {},
+            allowShortCircuit = config.allowShortCircuit || false,
+            allowTernary = config.allowTernary || false,
+            allowDoExpression = config.allowDoExpression || true;
+
+        /**
+         * @param {ASTNode} node - any node
+         * @returns {boolean} whether the given node structurally represents a directive
+         */
+        function looksLikeDirective(node) {
+            return node.type === "ExpressionStatement" &&
+                node.expression.type === "Literal" && typeof node.expression.value === "string";
+        }
+
+        /**
+         * @param {Function} predicate - ([a] -> Boolean) the function used to make the determination
+         * @param {a[]} list - the input list
+         * @returns {a[]} the leading sequence of members in the given list that pass the given predicate
+         */
+        function takeWhile(predicate, list) {
+            for (let i = 0; i < list.length; ++i) {
+                if (!predicate(list[i])) {
+                    return list.slice(0, i);
+                }
+            }
+            return list.slice();
+        }
+
+        /**
+         * @param {ASTNode} node - a Program or BlockStatement node
+         * @returns {ASTNode[]} the leading sequence of directive nodes in the given node's body
+         */
+        function directives(node) {
+            return takeWhile(looksLikeDirective, node.body);
+        }
+
+        /**
+         * @param {ASTNode} node - any node
+         * @param {ASTNode[]} ancestors - the given node's ancestors
+         * @returns {boolean} whether the given node is considered a directive in its current position
+         */
+        function isDirective(node, ancestors) {
+            const parent = ancestors[ancestors.length - 1],
+                grandparent = ancestors[ancestors.length - 2];
+
+            return (parent.type === "Program" || parent.type === "BlockStatement" &&
+                    (/Function/.test(grandparent.type))) &&
+                    directives(parent).indexOf(node) >= 0;
+        }
+      
+        
+        /**
+         * @param {ASTNode} node - any node
+         * @param {ASTNode[]} ancestors - the given node's ancestors
+         * @returns {boolean} whether the given node is within a Do Expression
+         */
+        function isInDoExpression(node, ancestors) {
+            return (ancestors.reduce(function(inDoExpression, ancestor) { 
+                return inDoExpression || ancestor.type === "DoExpression";
+            }, false));
+        }
+
+        /**
+         * Determines whether or not a given node is a valid expression. Recurses on short circuit eval and ternary nodes if enabled by flags.
+         * @param {ASTNode} node - any node
+         * @returns {boolean} whether the given node is a valid expression
+         */
+        function isValidExpression(node) {
+          
+            if (allowDoExpression) {
+                return isInDoExpression(node, context.getAncestors());
+            }
+
+            if (allowTernary) {
+
+                // Recursive check for ternary and logical expressions
+                if (node.type === "ConditionalExpression") {
+                    return isValidExpression(node.consequent) && isValidExpression(node.alternate);
+                }
+            }
+            if (allowShortCircuit) {
+                if (node.type === "LogicalExpression") {
+                    return isValidExpression(node.right);
+                }
+            }
+
+            return /^(?:Assignment|Call|New|Update|Yield|Await)Expression$/.test(node.type) ||
+                (node.type === "UnaryExpression" && ["delete", "void"].indexOf(node.operator) >= 0);
+        }
+
+        return {
+            ExpressionStatement(node) {
+                if (!isValidExpression(node.expression) && !isDirective(node, context.getAncestors())) {
+                    context.report({ node, message: "Expected an assignment or function call and instead saw an expression." });
+                }
+            }
+        };
+
+    }
+};


### PR DESCRIPTION
naive solution to https://github.com/babel/eslint-plugin-babel/issues/13 (and related)

It's not perfect, as it just walks the ancestor tree and allows the expression if there's a do { } above the node in the ancestor tree.  I'm not sure there's a better solution given the syntax possibilities with do expressions, so I think this should be a good start.  I've added it behind an option so it can be turned off, with it defaulted on (as I think it's what most people will want if they've specifically added it from the eslint-plugin-babel ruleset).