### PR TITLE
Updated deprecated rules to new format and added deprecated flag to their meta object

### DIFF
--- a/rules/array-bracket-spacing.js
+++ b/rules/array-bracket-spacing.js
@@ -1,39 +1,43 @@
 "use strict";
 
 var isWarnedForDeprecation = false;
-module.exports = function() {
-    return {
-        Program() {
-            if (isWarnedForDeprecation || /\=-(f|-format)=/.test(process.argv.join('='))) {
-              return;
+module.exports = {
+    meta: {
+        deprecated: true,
+        schema: [
+            {
+                "enum": ["always", "never"]
+            },
+            {
+                "type": "object",
+                "properties": {
+                    "singleValue": {
+                        "type": "boolean"
+                    },
+                    "objectsInArrays": {
+                        "type": "boolean"
+                    },
+                    "arraysInArrays": {
+                        "type": "boolean"
+                    }
+                },
+                "additionalProperties": false
             }
-
-            /* eslint-disable no-console */
-            console.log('The babel/array-bracket-spacing rule is deprecated. Please ' +
-                        'use the built in array-bracket-spacing rule instead.');
-            /* eslint-enable no-console */
-            isWarnedForDeprecation = true;
-        }
-    };
-};
-
-module.exports.schema = [
-    {
-        "enum": ["always", "never"]
+        ]
     },
-    {
-        "type": "object",
-        "properties": {
-            "singleValue": {
-                "type": "boolean"
-            },
-            "objectsInArrays": {
-                "type": "boolean"
-            },
-            "arraysInArrays": {
-                "type": "boolean"
+    create: function() {
+        return {
+            Program: function() {
+                if (isWarnedForDeprecation || /\=-(f|-format)=/.test(process.argv.join('='))) {
+                    return;
+                }
+
+                /* eslint-disable no-console */
+                console.log('The babel/array-bracket-spacing rule is deprecated. Please ' +
+                            'use the built in array-bracket-spacing rule instead.');
+                /* eslint-enable no-console */
+                isWarnedForDeprecation = true;
             }
-        },
-        "additionalProperties": false
+        };
     }
-];
+};

--- a/rules/arrow-parens.js
+++ b/rules/arrow-parens.js
@@ -1,24 +1,28 @@
 "use strict";
 
 var isWarnedForDeprecation = false;
-module.exports = function() {
-    return {
-        Program() {
-            if (isWarnedForDeprecation || /\=-(f|-format)=/.test(process.argv.join('='))) {
-              return;
+module.exports = {
+    meta: {
+        deprecated: true,
+        schema: [
+            {
+                "enum": ["always", "as-needed"]
             }
+        ]
+    },
+    create: function() {
+        return {
+            Program: function() {
+                if (isWarnedForDeprecation || /\=-(f|-format)=/.test(process.argv.join('='))) {
+                    return;
+                }
 
-            /* eslint-disable no-console */
-            console.log('The babel/arrow-parens rule is deprecated. Please ' +
-                        'use the built in arrow-parens rule instead.');
-            /* eslint-enable no-console */
-            isWarnedForDeprecation = true;
-        }
-    };
-};
-
-module.exports.schema = [
-    {
-        "enum": ["always", "as-needed"]
+                /* eslint-disable no-console */
+                console.log('The babel/arrow-parens rule is deprecated. Please ' +
+                            'use the built in arrow-parens rule instead.');
+                /* eslint-enable no-console */
+                isWarnedForDeprecation = true;
+            }
+        };
     }
-];
+};

--- a/rules/flow-object-type.js
+++ b/rules/flow-object-type.js
@@ -1,25 +1,29 @@
 "use strict";
 
 var isWarnedForDeprecation = false;
-module.exports = function() {
-    return {
-        Program() {
-            if (isWarnedForDeprecation || /\=-(f|-format)=/.test(process.argv.join('='))) {
-              return;
+module.exports = {
+    meta: {
+        deprecated: true,
+        schema: [
+            {
+                "enum": ["semicolon", "comma"],
             }
+        ]
+    },
+    create: function() {
+        return {
+            Program: function() {
+                if (isWarnedForDeprecation || /\=-(f|-format)=/.test(process.argv.join('='))) {
+                    return;
+                }
 
-            /* eslint-disable no-console */
-            console.log('The babel/flow-object-type rule is deprecated. Please ' +
-                        'use the flowtype/object-type-delimiter rule instead.\n' +
-                        'Check out https://github.com/gajus/eslint-plugin-flowtype#eslint-plugin-flowtype-rules-object-type-delimiter');
-            /* eslint-enable no-console */
-            isWarnedForDeprecation = true;
-        }
-    };
+                /* eslint-disable no-console */
+                console.log('The babel/flow-object-type rule is deprecated. Please ' +
+                            'use the flowtype/object-type-delimiter rule instead.\n' +
+                            'Check out https://github.com/gajus/eslint-plugin-flowtype#eslint-plugin-flowtype-rules-object-type-delimiter');
+                /* eslint-enable no-console */
+                isWarnedForDeprecation = true;
+            }
+        };
+    }
 };
-
-module.exports.schema = [
-  {
-    'enum': ['semicolon', 'comma'],
-  }
-];

--- a/rules/func-params-comma-dangle.js
+++ b/rules/func-params-comma-dangle.js
@@ -1,24 +1,28 @@
 'use strict';
 
 var isWarnedForDeprecation = false;
-module.exports = function() {
-    return {
-        Program() {
-            if (isWarnedForDeprecation || /\=-(f|-format)=/.test(process.argv.join('='))) {
-              return;
+module.exports = {
+    meta: {
+        deprecated: true,
+        schema: [
+            {
+                "enum": ["always", "always-multiline", "only-multiline", "never"]
             }
+        ]
+    },
+    create: function() {
+        return {
+            Program: function() {
+                if (isWarnedForDeprecation || /\=-(f|-format)=/.test(process.argv.join('='))) {
+                    return;
+                }
 
-            /* eslint-disable no-console */
-            console.log('The babel/func-params-comma-dangle rule is deprecated. Please ' +
-                        'use the built in comma-dangle rule instead.');
-            /* eslint-enable no-console */
-            isWarnedForDeprecation = true;
-        }
-    };
+                /* eslint-disable no-console */
+                console.log('The babel/func-params-comma-dangle rule is deprecated. Please ' +
+                            'use the built in comma-dangle rule instead.');
+                /* eslint-enable no-console */
+                isWarnedForDeprecation = true;
+            }
+        };
+    }
 };
-
-module.exports.schema =  [
-  {
-    enum: ['always', 'always-multiline', 'only-multiline', 'never']
-  }
-];

--- a/rules/generator-star-spacing.js
+++ b/rules/generator-star-spacing.js
@@ -1,36 +1,40 @@
 "use strict";
 
 var isWarnedForDeprecation = false;
-module.exports = function() {
-    return {
-        Program() {
-            if (isWarnedForDeprecation || /\=-(f|-format)=/.test(process.argv.join('='))) {
-              return;
-            }
-
-            /* eslint-disable no-console */
-            console.log('The babel/generator-star-spacing rule is deprecated. Please ' +
-                        'use the built in generator-star-spacing rule instead.');
-            /* eslint-enable no-console */
-            isWarnedForDeprecation = true;
-        }
-    };
-};
-
-module.exports.schema = [
-    {
-        "oneOf": [
+module.exports = {
+    meta: {
+        deprecated: true,
+        schema: [
             {
-                "enum": ["before", "after", "both", "neither"]
-            },
-            {
-                "type": "object",
-                "properties": {
-                    "before": {"type": "boolean"},
-                    "after": {"type": "boolean"}
-                },
-                "additionalProperties": false
+                "oneOf": [
+                    {
+                        "enum": ["before", "after", "both", "neither"]
+                    },
+                    {
+                        "type": "object",
+                        "properties": {
+                            "before": {"type": "boolean"},
+                            "after": {"type": "boolean"}
+                        },
+                        "additionalProperties": false
+                    }
+                ]
             }
         ]
+    },
+    create: function() {
+        return {
+            Program: function() {
+                if (isWarnedForDeprecation || /\=-(f|-format)=/.test(process.argv.join('='))) {
+                    return;
+                }
+
+                /* eslint-disable no-console */
+                console.log('The babel/generator-star-spacing rule is deprecated. Please ' +
+                            'use the built in generator-star-spacing rule instead.');
+                /* eslint-enable no-console */
+                isWarnedForDeprecation = true;
+            }
+        };
     }
-];
+};

--- a/rules/object-shorthand.js
+++ b/rules/object-shorthand.js
@@ -1,24 +1,28 @@
 "use strict";
 
 var isWarnedForDeprecation = false;
-module.exports = function() {
-    return {
-        Program() {
-            if (isWarnedForDeprecation || /\=-(f|-format)=/.test(process.argv.join('='))) {
-              return;
+module.exports = {
+    meta: {
+        deprecated: true,
+        schema: [
+            {
+                "enum": ["always", "methods", "properties", "never"]
             }
+        ]
+    },
+    create: function() {
+        return {
+            Program: function() {
+                if (isWarnedForDeprecation || /\=-(f|-format)=/.test(process.argv.join('='))) {
+                    return;
+                }
 
-            /* eslint-disable no-console */
-            console.log('The babel/object-shorthand rule is deprecated. Please ' +
-                        'use the built in object-shorthand rule instead.');
-            /* eslint-enable no-console */
-            isWarnedForDeprecation = true;
-        }
-    };
+                /* eslint-disable no-console */
+                console.log('The babel/object-shorthand rule is deprecated. Please ' +
+                            'use the built in object-shorthand rule instead.');
+                /* eslint-enable no-console */
+                isWarnedForDeprecation = true;
+            }
+        };
+    }
 };
-
-module.exports.schema = [
-  {
-    'enum': ['always', 'methods', 'properties', 'never']
-  }
-];


### PR DESCRIPTION
In order to programmatically document the `deprecated` rules, I had to upgrade each of them to the [new ESLint rule format](http://eslint.org/docs/developer-guide/working-with-rules). 

Alongside the `schema` array, you will see the addition of the `deprecated` flag in each rules `meta` object.

This PR should [resolve this issue](https://github.com/babel/eslint-plugin-babel/issues/118#issuecomment-273203318).