### PR TITLE
Allow disabling new-cap on object properties

### DIFF
--- a/rules/new-cap.js
+++ b/rules/new-cap.js
@@ -71,6 +71,7 @@ module.exports = function(context) {
     var config = context.options[0] || {};
     var NEW_IS_CAP = config.newIsCap !== false;
     var CAP_IS_NEW = config.capIsNew !== false;
+    var skipProperties = config.properties === false;
 
     var newIsCapExceptions = checkArray(config, "newIsCapExceptions", []).reduce(invert, {});
 
@@ -153,7 +154,8 @@ module.exports = function(context) {
             return node.callee.object.type === "Identifier" &&
                 node.callee.object.name === "Date";
         }
-        return false;
+
+        return skipProperties && node.callee.type === "MemberExpression";
     }
 
     /**
@@ -228,6 +230,9 @@ module.exports.schema = [
                 "items": {
                     "type": "string"
                 }
+            },
+            "properties": {
+                "type": "boolean"
             }
         },
         "additionalProperties": false

--- a/tests/rules/new-cap.js
+++ b/tests/rules/new-cap.js
@@ -39,6 +39,7 @@ ruleTester.run('babel/new-cap', rule, {
         "var x = $();",
         { code: "var x = Foo(42)", options: [{"capIsNew": false}] },
         { code: "var x = bar.Foo(42)", options: [{"capIsNew": false}] },
+        { code: "var x = Foo.bar(42)", options: [{"capIsNew": false}] },
         "var x = bar[Foo](42)",
         {code: "var x = bar['Foo'](42)", options: [{"capIsNew": false}] },
         "var x = Foo.bar(42)",
@@ -53,6 +54,10 @@ ruleTester.run('babel/new-cap', rule, {
         { code: "var x = Foo.Bar(42);", options: [{ capIsNewExceptions: ["Foo.Bar"] }] },
         { code: "var x = new foo.bar(42);", options: [{ newIsCapExceptions: ["bar"] }] },
         { code: "var x = new foo.bar(42);", options: [{ newIsCapExceptions: ["foo.bar"] }] },
+
+        { code: "var x = new foo.bar(42);", options: [{ properties: false }] },
+        { code: "var x = Foo.bar(42);", options: [{ properties: false }] },
+        { code: "var x = foo.Bar(42);", options: [{ capIsNew: false, properties: false }] },
 
         // Babel-specific test cases.
         { code: "@MyDecorator(123) class MyClass{}", parser: "babel-eslint" },


### PR DESCRIPTION
Ported from built-in new-cap:
https://github.com/eslint/eslint/commit/4222799f742b16a8ed18c0bc13f6c143622c732f

Fixes #124