### PR TITLE
Modifying semi rule to support for await

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Each rule corresponds to a core `eslint` rule, and has the same options.
 - `babel/new-cap`: Ignores capitalized decorators (`@Decorator`)
 - `babel/object-curly-spacing`: doesn't complain about `export x from "mod";` or `export * as x from "mod";` (🛠)
 - `babel/no-invalid-this`: doesn't fail when inside class properties (`class A { a = this.b; }`)
-- `babel/semi`: Includes class properties (🛠)
+- `babel/semi`: doesn't fail when using `for await (let something of {})`. Includes class properties (🛠)
 
 #### Deprecated
 

--- a/rules/semi.js
+++ b/rules/semi.js
@@ -187,7 +187,7 @@ module.exports = {
                 parent = ancestors[parentIndex];
 
             if ((parent.type !== "ForStatement" || parent.init !== node) &&
-                (!/^For(?:In|Of)Statement/.test(parent.type) || parent.left !== node)
+                (!/^For(?:In|Of|Await)Statement/.test(parent.type) || parent.left !== node)
             ) {
                 checkForSemicolon(node);
             }

--- a/tests/rules/semi.js
+++ b/tests/rules/semi.js
@@ -102,6 +102,7 @@ ruleTester.run("semi", rule, {
         // babel
         "class Foo { bar = 'example'; }",
         "class Foo { static bar = 'example'; }",
+        { code: "async function foo() { for await (let thing of {}) { console.log(thing); } }", parserOptions: { ecmaVersion: 6 } },
 
         // babel, "never"
         { code: "class Foo { bar = 'example' }", options: ["never"] },


### PR DESCRIPTION
The [async iterator proposal](https://github.com/tc39/proposal-async-iteration) adds support for the following code

```
for await (const line of readLines(filePath)) {
  console.log(line);
}

async function* readLines(path) {
  let file = await fileOpen(path);

  try {
    while (!file.EOF) {
      yield await file.readLine();
    }
  } finally {
    await file.close();
  }
}
```

However, the ESLint rule expects there to be a semi-colon. Since this is currently a stage-3 proposal, the ESLint team has declined implementing it at this time per https://github.com/eslint/eslint/pull/7417

