### PR TITLE
Add `no-shadow-restricted-names` rule (optional catch binding)

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Each rule corresponds to a core `eslint` rule, and has the same options.
 - `babel/object-curly-spacing`: doesn't complain about `export x from "mod";` or `export * as x from "mod";` (🛠)
 - `babel/no-invalid-this`: doesn't fail when inside class properties (`class A { a = this.b; }`)
 - `babel/semi`: doesn't fail when using `for await (let something of {})`. Includes class properties (🛠)
+- `babel/no-shadow-restricted-names`: doesn't fail on optional catch binding `try {} catch {}`
 
 #### Deprecated
 

--- a/index.js
+++ b/index.js
@@ -13,6 +13,7 @@ module.exports = {
     'func-params-comma-dangle': require('./rules/func-params-comma-dangle'),
     'no-invalid-this': require('./rules/no-invalid-this'),
     'semi': require('./rules/semi'),
+    'no-shadow-restricted-names': require('./rules/no-shadow-restricted-names'),
   },
   rulesConfig: {
     'generator-star-spacing': 0,
@@ -26,5 +27,6 @@ module.exports = {
     'func-params-comma-dangle': 0,
     'no-invalid-this': 0,
     'semi': 0,
+    'no-shadow-restricted-names': 0,
   }
 };

--- a/rules/no-shadow-restricted-names.js
+++ b/rules/no-shadow-restricted-names.js
@@ -1,0 +1,72 @@
+/**
+ * @fileoverview Disallow shadowing of NaN, undefined, and Infinity (ES5 section 15.1.1)
+ * @author Michael Ficarra
+ */
+"use strict";
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+module.exports = {
+    meta: {
+        docs: {
+            description: "disallow identifiers from shadowing restricted names",
+            category: "Variables",
+            recommended: false
+        },
+
+        schema: []
+    },
+
+    create(context) {
+
+        const RESTRICTED = ["undefined", "NaN", "Infinity", "arguments", "eval"];
+
+        /**
+         * Check if the node name is present inside the restricted list
+         * @param {ASTNode} id id to evaluate
+         * @returns {void}
+         * @private
+         */
+        function checkForViolation(id) {
+            if (RESTRICTED.indexOf(id.name) > -1) {
+                context.report({
+                    node: id,
+                    message: "Shadowing of global property '{{idName}}'.",
+                    data: {
+                        idName: id.name
+                    }
+                });
+            }
+        }
+
+        return {
+            VariableDeclarator(node) {
+                checkForViolation(node.id);
+            },
+            ArrowFunctionExpression(node) {
+                [].map.call(node.params, checkForViolation);
+            },
+            FunctionExpression(node) {
+                if (node.id) {
+                    checkForViolation(node.id);
+                }
+                [].map.call(node.params, checkForViolation);
+            },
+            FunctionDeclaration(node) {
+                if (node.id) {
+                    checkForViolation(node.id);
+                    [].map.call(node.params, checkForViolation);
+                }
+            },
+            CatchClause(node) {
+              // don't check `param` if not present (optional catch binding)
+              if (node.param) {
+                checkForViolation(node.param);
+              }
+            }
+        };
+
+    }
+};

--- a/tests/rules/no-shadow-restricted-names.js
+++ b/tests/rules/no-shadow-restricted-names.js
@@ -1,0 +1,101 @@
+/**
+ * @fileoverview Disallow shadowing of NaN, undefined, and Infinity (ES5 section 15.1.1)
+ * @author Michael Ficarra
+ */
+
+"use strict";
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+var rule = require('../../rules/no-shadow-restricted-names'),
+    RuleTester = require('../RuleTester');
+
+const ruleTester = new RuleTester();
+
+ruleTester.run("babel/no-shadow-restricted-names", rule, {
+    valid: [
+        "function foo(bar){ var baz; }",
+        "!function foo(bar){ var baz; }",
+        "!function(bar){ var baz; }",
+        "try {} catch(e) {}",
+        { code: "export default function() {}", parserOptions: { sourceType: "module" } },
+        // Babel-specific test cases.
+        "try {} catch {}"
+    ],
+    invalid: [
+        {
+            code: "function NaN(NaN) { var NaN; !function NaN(NaN) { try {} catch(NaN) {} }; }",
+            parserOptions: { sourceType: "script" },
+            errors: [
+                { message: "Shadowing of global property 'NaN'.", type: "Identifier" },
+                { message: "Shadowing of global property 'NaN'.", type: "Identifier" },
+                { message: "Shadowing of global property 'NaN'.", type: "Identifier" },
+                { message: "Shadowing of global property 'NaN'.", type: "Identifier" },
+                { message: "Shadowing of global property 'NaN'.", type: "Identifier" },
+                { message: "Shadowing of global property 'NaN'.", type: "Identifier" }
+            ]
+        },
+        {
+            code: "function undefined(undefined) { var undefined; !function undefined(undefined) { try {} catch(undefined) {} }; }",
+            parserOptions: { sourceType: "script" },
+            errors: [
+                { message: "Shadowing of global property 'undefined'.", type: "Identifier" },
+                { message: "Shadowing of global property 'undefined'.", type: "Identifier" },
+                { message: "Shadowing of global property 'undefined'.", type: "Identifier" },
+                { message: "Shadowing of global property 'undefined'.", type: "Identifier" },
+                { message: "Shadowing of global property 'undefined'.", type: "Identifier" },
+                { message: "Shadowing of global property 'undefined'.", type: "Identifier" }
+            ]
+        },
+        {
+            code: "function Infinity(Infinity) { var Infinity; !function Infinity(Infinity) { try {} catch(Infinity) {} }; }",
+            parserOptions: { sourceType: "script" },
+            errors: [
+                { message: "Shadowing of global property 'Infinity'.", type: "Identifier" },
+                { message: "Shadowing of global property 'Infinity'.", type: "Identifier" },
+                { message: "Shadowing of global property 'Infinity'.", type: "Identifier" },
+                { message: "Shadowing of global property 'Infinity'.", type: "Identifier" },
+                { message: "Shadowing of global property 'Infinity'.", type: "Identifier" },
+                { message: "Shadowing of global property 'Infinity'.", type: "Identifier" }
+            ]
+        },
+        {
+            code: "function arguments(arguments) { var arguments; !function arguments(arguments) { try {} catch(arguments) {} }; }",
+            parserOptions: { sourceType: "script" },
+            errors: [
+                { message: "Shadowing of global property 'arguments'.", type: "Identifier" },
+                { message: "Shadowing of global property 'arguments'.", type: "Identifier" },
+                { message: "Shadowing of global property 'arguments'.", type: "Identifier" },
+                { message: "Shadowing of global property 'arguments'.", type: "Identifier" },
+                { message: "Shadowing of global property 'arguments'.", type: "Identifier" },
+                { message: "Shadowing of global property 'arguments'.", type: "Identifier" }
+            ]
+        },
+        {
+            code: "function eval(eval) { var eval; !function eval(eval) { try {} catch(eval) {} }; }",
+            parserOptions: { sourceType: "script" },
+            errors: [
+                { message: "Shadowing of global property 'eval'.", type: "Identifier" },
+                { message: "Shadowing of global property 'eval'.", type: "Identifier" },
+                { message: "Shadowing of global property 'eval'.", type: "Identifier" },
+                { message: "Shadowing of global property 'eval'.", type: "Identifier" },
+                { message: "Shadowing of global property 'eval'.", type: "Identifier" },
+                { message: "Shadowing of global property 'eval'.", type: "Identifier" }
+            ]
+        },
+        {
+            code: "var eval = (eval) => { var eval; !function eval(eval) { try {} catch(eval) {} }; }",
+            parserOptions: { sourceType: "script" },
+            errors: [
+                { message: "Shadowing of global property 'eval'.", type: "Identifier" },
+                { message: "Shadowing of global property 'eval'.", type: "Identifier" },
+                { message: "Shadowing of global property 'eval'.", type: "Identifier" },
+                { message: "Shadowing of global property 'eval'.", type: "Identifier" },
+                { message: "Shadowing of global property 'eval'.", type: "Identifier" },
+                { message: "Shadowing of global property 'eval'.", type: "Identifier" }
+            ]
+        }
+    ]
+});


### PR DESCRIPTION
This PR fixes original `no-shadow-restricted-names` rule to work with optional catch binding (https://github.com/tc39/proposal-optional-catch-binding).

(`CatchClause` visitor does not check `param` if not present.)