### PR TITLE
Add babel/quotes rule for JSXFragment workaround

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,9 @@ original ones as well!).
 {
   "rules": {
     "babel/new-cap": 1,
-    "babel/object-curly-spacing": 1,
     "babel/no-invalid-this": 1,
+    "babel/object-curly-spacing": 1,
+    "babel/quotes": 1,
     "babel/semi": 1
   }
 }
@@ -42,8 +43,9 @@ Each rule corresponds to a core `eslint` rule, and has the same options.
 🛠: means it's autofixable with `--fix`.
 
 - `babel/new-cap`: Ignores capitalized decorators (`@Decorator`)
-- `babel/object-curly-spacing`: doesn't complain about `export x from "mod";` or `export * as x from "mod";` (🛠)
 - `babel/no-invalid-this`: doesn't fail when inside class properties (`class A { a = this.b; }`)
+- `babel/object-curly-spacing`: doesn't complain about `export x from "mod";` or `export * as x from "mod";` (🛠)
+- `babel/quotes`: doesn't complain about JSX fragment shorthand syntax (`<>foo</>;`)
 - `babel/semi`: doesn't fail when using `for await (let something of {})`. Includes class properties (🛠)
 
 #### Deprecated

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "eslint-rule-composer": "^0.1.1"
   },
   "devDependencies": {
-    "babel-eslint": "^7.1.0",
+    "babel-eslint": "^8.2.2",
     "eslint": "^4.19.1",
     "lodash.clonedeep": "^4.5.0",
     "mocha": "^3.0.0"

--- a/rules/quotes.js
+++ b/rules/quotes.js
@@ -1,0 +1,18 @@
+'use strict';
+
+const ruleComposer = require('eslint-rule-composer');
+const eslint = require('eslint');
+const quotesRule = new eslint.Linter().getRules().get('quotes');
+
+module.exports = ruleComposer.filterReports(
+  quotesRule,
+  (problem, metadata) => {
+    // Workaround for JSX fragment syntax until
+    // https://github.com/eslint/eslint/issues/9662
+    if (problem.node.parent.type === "JSXFragment") {
+      return false;
+    }
+
+    return true;
+  }
+);

--- a/tests/rules/quotes.js
+++ b/tests/rules/quotes.js
@@ -1,0 +1,320 @@
+var rule = require('../../rules/quotes'),
+    RuleTester = require('../RuleTester');
+
+var ruleTester = new RuleTester();
+ruleTester.run('babel/quotes', rule, {
+    valid: [
+        "var foo = \"bar\";",
+        { code: "var foo = 'bar';", options: ["single"] },
+        { code: "var foo = \"bar\";", options: ["double"] },
+        { code: "var foo = 1;", options: ["single"] },
+        { code: "var foo = 1;", options: ["double"] },
+        { code: "var foo = \"'\";", options: ["single", { avoidEscape: true }] },
+        { code: "var foo = '\"';", options: ["double", { avoidEscape: true }] },
+        { code: "var foo = <div>Hello world</div>;", options: ["single"], parserOptions: { ecmaVersion: 6, ecmaFeatures: { jsx: true } } },
+        { code: "var foo = <div id=\"foo\"></div>;", options: ["single"], parserOptions: { ecmaVersion: 6, ecmaFeatures: { jsx: true } } },
+        { code: "var foo = <div>Hello world</div>;", options: ["double"], parserOptions: { ecmaVersion: 6, ecmaFeatures: { jsx: true } } },
+        { code: "var foo = <div>Hello world</div>;", options: ["double", { avoidEscape: true }], parserOptions: { ecmaVersion: 6, ecmaFeatures: { jsx: true } } },
+        { code: "var foo = `bar`;", options: ["backtick"], parserOptions: { ecmaVersion: 6 } },
+        { code: "var foo = `bar 'baz'`;", options: ["backtick"], parserOptions: { ecmaVersion: 6 } },
+        { code: "var foo = `bar \"baz\"`;", options: ["backtick"], parserOptions: { ecmaVersion: 6 } },
+        { code: "var foo = 1;", options: ["backtick"] },
+        { code: "var foo = \"a string containing `backtick` quotes\";", options: ["backtick", { avoidEscape: true }] },
+        { code: "var foo = <div id=\"foo\"></div>;", options: ["backtick"], parserOptions: { ecmaVersion: 6, ecmaFeatures: { jsx: true } } },
+        { code: "var foo = <div>Hello world</div>;", options: ["backtick"], parserOptions: { ecmaVersion: 6, ecmaFeatures: { jsx: true } } },
+
+        // Backticks are only okay if they have substitutions, contain a line break, or are tagged
+        { code: "var foo = `back\ntick`;", options: ["single"], parserOptions: { ecmaVersion: 6 } },
+        { code: "var foo = `back\rtick`;", options: ["single"], parserOptions: { ecmaVersion: 6 } },
+        { code: "var foo = `back\u2028tick`;", options: ["single"], parserOptions: { ecmaVersion: 6 } },
+        { code: "var foo = `back\u2029tick`;", options: ["single"], parserOptions: { ecmaVersion: 6 } },
+        {
+            code: "var foo = `back\\\\\ntick`;", // 2 backslashes followed by a newline
+            options: ["single"],
+            parserOptions: { ecmaVersion: 6 }
+        },
+        { code: "var foo = `back\\\\\\\\\ntick`;", options: ["single"], parserOptions: { ecmaVersion: 6 } },
+        { code: "var foo = `\n`;", options: ["single"], parserOptions: { ecmaVersion: 6 } },
+        { code: "var foo = `back${x}tick`;", options: ["double"], parserOptions: { ecmaVersion: 6 } },
+        { code: "var foo = tag`backtick`;", options: ["double"], parserOptions: { ecmaVersion: 6 } },
+
+        // Backticks are also okay if allowTemplateLiterals
+        { code: "var foo = `bar 'foo' baz` + 'bar';", options: ["single", { allowTemplateLiterals: true }], parserOptions: { ecmaVersion: 6 } },
+        { code: "var foo = `bar 'foo' baz` + \"bar\";", options: ["double", { allowTemplateLiterals: true }], parserOptions: { ecmaVersion: 6 } },
+        { code: "var foo = `bar 'foo' baz` + `bar`;", options: ["backtick", { allowTemplateLiterals: true }], parserOptions: { ecmaVersion: 6 } },
+
+        // `backtick` should not warn the directive prologues.
+        { code: "\"use strict\"; var foo = `backtick`;", options: ["backtick"], parserOptions: { ecmaVersion: 6 } },
+        { code: "\"use strict\"; 'use strong'; \"use asm\"; var foo = `backtick`;", options: ["backtick"], parserOptions: { ecmaVersion: 6 } },
+        { code: "function foo() { \"use strict\"; \"use strong\"; \"use asm\"; var foo = `backtick`; }", options: ["backtick"], parserOptions: { ecmaVersion: 6 } },
+        { code: "(function() { 'use strict'; 'use strong'; 'use asm'; var foo = `backtick`; })();", options: ["backtick"], parserOptions: { ecmaVersion: 6 } },
+        { code: "(() => { \"use strict\"; \"use strong\"; \"use asm\"; var foo = `backtick`; })();", options: ["backtick"], parserOptions: { ecmaVersion: 6 } },
+
+        // `backtick` should not warn import/export sources.
+        { code: "import \"a\"; import 'b';", options: ["backtick"], parserOptions: { sourceType: "module" } },
+        { code: "import a from \"a\"; import b from 'b';", options: ["backtick"], parserOptions: { sourceType: "module" } },
+        { code: "export * from \"a\"; export * from 'b';", options: ["backtick"], parserOptions: { sourceType: "module" } },
+
+        // `backtick` should not warn property/method names (not computed).
+        { code: "var obj = {\"key0\": 0, 'key1': 1};", options: ["backtick"], parserOptions: { ecmaVersion: 6 } },
+        { code: "class Foo { 'bar'(){} }", options: ["backtick"], parserOptions: { ecmaVersion: 6 } },
+        { code: "class Foo { static ''(){} }", options: ["backtick"], parserOptions: { ecmaVersion: 6 } },
+
+        // Babel
+        '<>foo</>;',
+        { code: '<>foo</>;', options: ['single'] },
+        { code: '<>foo</>;', options: ['double'] },
+        '<><div /><div /></>;',
+        { code: '<><div /><div /></>;', options: ['single'] },
+        { code: '<><div /><div /></>;', options: ['double'] },
+    ],
+    invalid: [
+        {
+          code: "var foo = 'bar';",
+          output: "var foo = \"bar\";",
+          errors: [{ message: "Strings must use doublequote.", type: "Literal" }]
+        },
+        {
+            code: "var foo = \"bar\";",
+            output: "var foo = 'bar';",
+            options: ["single"],
+            errors: [{ message: "Strings must use singlequote.", type: "Literal" }]
+        },
+        {
+            code: "var foo = `bar`;",
+            output: "var foo = 'bar';",
+            options: ["single"],
+            parserOptions: {
+                ecmaVersion: 6
+            },
+            errors: [{ message: "Strings must use singlequote.", type: "TemplateLiteral" }]
+        },
+        {
+            code: "var foo = 'don\\'t';",
+            output: "var foo = \"don't\";",
+            errors: [{ message: "Strings must use doublequote.", type: "Literal" }]
+        },
+        {
+            code: "var msg = \"Plugin '\" + name + \"' not found\"",
+            output: "var msg = 'Plugin \\'' + name + '\\' not found'",
+            options: ["single"],
+            errors: [
+                { message: "Strings must use singlequote.", type: "Literal", column: 11 },
+                { message: "Strings must use singlequote.", type: "Literal", column: 31 }
+            ]
+        },
+        {
+            code: "var foo = 'bar';",
+            output: "var foo = \"bar\";",
+            options: ["double"],
+            errors: [{ message: "Strings must use doublequote.", type: "Literal" }]
+        },
+        {
+            code: "var foo = `bar`;",
+            output: "var foo = \"bar\";",
+            options: ["double"],
+            parserOptions: {
+                ecmaVersion: 6
+            },
+            errors: [{ message: "Strings must use doublequote.", type: "TemplateLiteral" }]
+        },
+        {
+            code: "var foo = \"bar\";",
+            output: "var foo = 'bar';",
+            options: ["single", { avoidEscape: true }],
+            errors: [{ message: "Strings must use singlequote.", type: "Literal" }]
+        },
+        {
+            code: "var foo = 'bar';",
+            output: "var foo = \"bar\";",
+            options: ["double", { avoidEscape: true }],
+            errors: [{ message: "Strings must use doublequote.", type: "Literal" }]
+        },
+        {
+            code: "var foo = '\\\\';",
+            output: "var foo = \"\\\\\";",
+            options: ["double", { avoidEscape: true }],
+            errors: [{ message: "Strings must use doublequote.", type: "Literal" }]
+        },
+        {
+            code: "var foo = \"bar\";",
+            output: "var foo = 'bar';",
+            options: ["single", { allowTemplateLiterals: true }],
+            errors: [{ message: "Strings must use singlequote.", type: "Literal" }]
+        },
+        {
+            code: "var foo = 'bar';",
+            output: "var foo = \"bar\";",
+            options: ["double", { allowTemplateLiterals: true }],
+            errors: [{ message: "Strings must use doublequote.", type: "Literal" }]
+        },
+        {
+            code: "var foo = 'bar';",
+            output: "var foo = `bar`;",
+            options: ["backtick"],
+            errors: [{ message: "Strings must use backtick.", type: "Literal" }]
+        },
+        {
+            code: "var foo = 'b${x}a$r';",
+            output: "var foo = `b\\${x}a$r`;",
+            options: ["backtick"],
+            errors: [{ message: "Strings must use backtick.", type: "Literal" }]
+        },
+        {
+            code: "var foo = \"bar\";",
+            output: "var foo = `bar`;",
+            options: ["backtick"],
+            errors: [{ message: "Strings must use backtick.", type: "Literal" }]
+        },
+        {
+            code: "var foo = \"bar\";",
+            output: "var foo = `bar`;",
+            options: ["backtick", { avoidEscape: true }],
+            errors: [{ message: "Strings must use backtick.", type: "Literal" }]
+        },
+        {
+            code: "var foo = 'bar';",
+            output: "var foo = `bar`;",
+            options: ["backtick", { avoidEscape: true }],
+            errors: [{ message: "Strings must use backtick.", type: "Literal" }]
+        },
+
+        // "use strict" is *not* a directive prologue in these statements so is subject to the rule
+        {
+            code: "var foo = `backtick`; \"use strict\";",
+            output: "var foo = `backtick`; `use strict`;",
+            options: ["backtick"],
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{ message: "Strings must use backtick.", type: "Literal" }]
+        },
+        {
+            code: "{ \"use strict\"; var foo = `backtick`; }",
+            output: "{ `use strict`; var foo = `backtick`; }",
+            options: ["backtick"],
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{ message: "Strings must use backtick.", type: "Literal" }]
+        },
+        {
+            code: "if (1) { \"use strict\"; var foo = `backtick`; }",
+            output: "if (1) { `use strict`; var foo = `backtick`; }",
+            options: ["backtick"],
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{ message: "Strings must use backtick.", type: "Literal" }]
+        },
+
+        // `backtick` should warn computed property names.
+        {
+            code: "var obj = {[\"key0\"]: 0, ['key1']: 1};",
+            output: "var obj = {[`key0`]: 0, [`key1`]: 1};",
+            options: ["backtick"],
+            parserOptions: { ecmaVersion: 6 },
+            errors: [
+                { message: "Strings must use backtick.", type: "Literal" },
+                { message: "Strings must use backtick.", type: "Literal" }
+            ]
+        },
+        {
+            code: "class Foo { ['a'](){} static ['b'](){} }",
+            output: "class Foo { [`a`](){} static [`b`](){} }",
+            options: ["backtick"],
+            parserOptions: { ecmaVersion: 6 },
+            errors: [
+                { message: "Strings must use backtick.", type: "Literal" },
+                { message: "Strings must use backtick.", type: "Literal" }
+            ]
+        },
+
+        // https://github.com/eslint/eslint/issues/7084
+        {
+            code: "<div blah={\"blah\"} />",
+            output: "<div blah={'blah'} />",
+            options: ["single"],
+            parserOptions: { ecmaFeatures: { jsx: true } },
+            errors: [
+                { message: "Strings must use singlequote.", type: "Literal" }
+            ]
+        },
+        {
+            code: "<div blah={'blah'} />",
+            output: "<div blah={\"blah\"} />",
+            options: ["double"],
+            parserOptions: { ecmaFeatures: { jsx: true } },
+            errors: [
+                { message: "Strings must use doublequote.", type: "Literal" }
+            ]
+        },
+        {
+            code: "<div blah={'blah'} />",
+            output: "<div blah={`blah`} />",
+            options: ["backtick"],
+            parserOptions: { ecmaFeatures: { jsx: true } },
+            errors: [
+                { message: "Strings must use backtick.", type: "Literal" }
+            ]
+        },
+
+        // https://github.com/eslint/eslint/issues/7610
+        {
+            code: "`use strict`;",
+            output: null,
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{ message: "Strings must use doublequote.", type: "TemplateLiteral" }]
+        },
+        {
+            code: "function foo() { `use strict`; foo(); }",
+            output: null,
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{ message: "Strings must use doublequote.", type: "TemplateLiteral" }]
+        },
+        {
+            code: "foo = function() { `use strict`; foo(); }",
+            output: null,
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{ message: "Strings must use doublequote.", type: "TemplateLiteral" }]
+        },
+        {
+            code: "() => { `use strict`; foo(); }",
+            output: null,
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{ message: "Strings must use doublequote.", type: "TemplateLiteral" }]
+        },
+        {
+            code: "() => { foo(); `use strict`; }",
+            output: "() => { foo(); \"use strict\"; }",
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{ message: "Strings must use doublequote.", type: "TemplateLiteral" }]
+        },
+        {
+            code: "foo(); `use strict`;",
+            output: "foo(); \"use strict\";",
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{ message: "Strings must use doublequote.", type: "TemplateLiteral" }]
+        },
+
+        // https://github.com/eslint/eslint/issues/7646
+        {
+            code: "var foo = `foo\\nbar`;",
+            output: "var foo = \"foo\\nbar\";",
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{ message: "Strings must use doublequote.", type: "TemplateLiteral" }]
+        },
+        {
+            code: "var foo = `foo\\\nbar`;", // 1 backslash followed by a newline
+            output: "var foo = \"foo\\\nbar\";",
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{ message: "Strings must use doublequote.", type: "TemplateLiteral" }]
+        },
+        {
+            code: "var foo = `foo\\\\\\\nbar`;", // 3 backslashes followed by a newline
+            output: "var foo = \"foo\\\\\\\nbar\";",
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{ message: "Strings must use doublequote.", type: "TemplateLiteral" }]
+        },
+        {
+            code: "````",
+            output: "\"\"``",
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{ message: "Strings must use doublequote.", type: "TemplateLiteral", line: 1, column: 1 }]
+        }
+    ],
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,82 @@
 # yarn lockfile v1
 
 
+"@babel/code-frame@7.0.0-beta.42", "@babel/code-frame@^7.0.0-beta.40":
+  version "7.0.0-beta.42"
+  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.0.0-beta.42.tgz#a9c83233fa7cd06b39dc77adbb908616ff4f1962"
+  dependencies:
+    "@babel/highlight" "7.0.0-beta.42"
+
+"@babel/generator@7.0.0-beta.42":
+  version "7.0.0-beta.42"
+  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.0.0-beta.42.tgz#777bb50f39c94a7e57f73202d833141f8159af33"
+  dependencies:
+    "@babel/types" "7.0.0-beta.42"
+    jsesc "^2.5.1"
+    lodash "^4.2.0"
+    source-map "^0.5.0"
+    trim-right "^1.0.1"
+
+"@babel/helper-function-name@7.0.0-beta.42":
+  version "7.0.0-beta.42"
+  resolved "https://registry.yarnpkg.com/@babel/helper-function-name/-/helper-function-name-7.0.0-beta.42.tgz#b38b8f4f85168d1812c543dd700b5d549b0c4658"
+  dependencies:
+    "@babel/helper-get-function-arity" "7.0.0-beta.42"
+    "@babel/template" "7.0.0-beta.42"
+    "@babel/types" "7.0.0-beta.42"
+
+"@babel/helper-get-function-arity@7.0.0-beta.42":
+  version "7.0.0-beta.42"
+  resolved "https://registry.yarnpkg.com/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0-beta.42.tgz#ad072e32f912c033053fc80478169aeadc22191e"
+  dependencies:
+    "@babel/types" "7.0.0-beta.42"
+
+"@babel/helper-split-export-declaration@7.0.0-beta.42":
+  version "7.0.0-beta.42"
+  resolved "https://registry.yarnpkg.com/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.0.0-beta.42.tgz#0d0d5254220a9cc4e7e226240306b939dc210ee7"
+  dependencies:
+    "@babel/types" "7.0.0-beta.42"
+
+"@babel/highlight@7.0.0-beta.42":
+  version "7.0.0-beta.42"
+  resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.0.0-beta.42.tgz#a502a1c0d6f99b2b0e81d468a1b0c0e81e3f3623"
+  dependencies:
+    chalk "^2.0.0"
+    esutils "^2.0.2"
+    js-tokens "^3.0.0"
+
+"@babel/template@7.0.0-beta.42":
+  version "7.0.0-beta.42"
+  resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.0.0-beta.42.tgz#7186d4e70d44cdec975049ba0a73bdaf5cdee052"
+  dependencies:
+    "@babel/code-frame" "7.0.0-beta.42"
+    "@babel/types" "7.0.0-beta.42"
+    babylon "7.0.0-beta.42"
+    lodash "^4.2.0"
+
+"@babel/traverse@^7.0.0-beta.40":
+  version "7.0.0-beta.42"
+  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.0.0-beta.42.tgz#f4bf4d1e33d41baf45205e2d0463591d57326285"
+  dependencies:
+    "@babel/code-frame" "7.0.0-beta.42"
+    "@babel/generator" "7.0.0-beta.42"
+    "@babel/helper-function-name" "7.0.0-beta.42"
+    "@babel/helper-split-export-declaration" "7.0.0-beta.42"
+    "@babel/types" "7.0.0-beta.42"
+    babylon "7.0.0-beta.42"
+    debug "^3.1.0"
+    globals "^11.1.0"
+    invariant "^2.2.0"
+    lodash "^4.2.0"
+
+"@babel/types@7.0.0-beta.42", "@babel/types@^7.0.0-beta.40":
+  version "7.0.0-beta.42"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.0.0-beta.42.tgz#1e2118767684880f6963801b272fd2b3348efacc"
+  dependencies:
+    esutils "^2.0.2"
+    lodash "^4.2.0"
+    to-fast-properties "^2.0.0"
+
 acorn-jsx@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-3.0.1.tgz#afdf9488fb1ecefc8348f6fb22f464e32a58b36b"
@@ -79,54 +155,20 @@ babel-code-frame@^6.22.0:
     esutils "^2.0.2"
     js-tokens "^3.0.0"
 
-babel-eslint@^7.1.0:
-  version "7.2.3"
-  resolved "https://registry.yarnpkg.com/babel-eslint/-/babel-eslint-7.2.3.tgz#b2fe2d80126470f5c19442dc757253a897710827"
+babel-eslint@^8.2.2:
+  version "8.2.2"
+  resolved "http://registry.npmjs.org/babel-eslint/-/babel-eslint-8.2.2.tgz#1102273354c6f0b29b4ea28a65f97d122296b68b"
   dependencies:
-    babel-code-frame "^6.22.0"
-    babel-traverse "^6.23.1"
-    babel-types "^6.23.0"
-    babylon "^6.17.0"
+    "@babel/code-frame" "^7.0.0-beta.40"
+    "@babel/traverse" "^7.0.0-beta.40"
+    "@babel/types" "^7.0.0-beta.40"
+    babylon "^7.0.0-beta.40"
+    eslint-scope "~3.7.1"
+    eslint-visitor-keys "^1.0.0"
 
-babel-messages@^6.23.0:
-  version "6.23.0"
-  resolved "https://registry.yarnpkg.com/babel-messages/-/babel-messages-6.23.0.tgz#f3cdf4703858035b2a2951c6ec5edf6c62f2630e"
-  dependencies:
-    babel-runtime "^6.22.0"
-
-babel-runtime@^6.22.0:
-  version "6.23.0"
-  resolved "https://registry.yarnpkg.com/babel-runtime/-/babel-runtime-6.23.0.tgz#0a9489f144de70efb3ce4300accdb329e2fc543b"
-  dependencies:
-    core-js "^2.4.0"
-    regenerator-runtime "^0.10.0"
-
-babel-traverse@^6.23.1:
-  version "6.25.0"
-  resolved "https://registry.yarnpkg.com/babel-traverse/-/babel-traverse-6.25.0.tgz#2257497e2fcd19b89edc13c4c91381f9512496f1"
-  dependencies:
-    babel-code-frame "^6.22.0"
-    babel-messages "^6.23.0"
-    babel-runtime "^6.22.0"
-    babel-types "^6.25.0"
-    babylon "^6.17.2"
-    debug "^2.2.0"
-    globals "^9.0.0"
-    invariant "^2.2.0"
-    lodash "^4.2.0"
-
-babel-types@^6.23.0, babel-types@^6.25.0:
-  version "6.25.0"
-  resolved "https://registry.yarnpkg.com/babel-types/-/babel-types-6.25.0.tgz#70afb248d5660e5d18f811d91c8303b54134a18e"
-  dependencies:
-    babel-runtime "^6.22.0"
-    esutils "^2.0.2"
-    lodash "^4.2.0"
-    to-fast-properties "^1.0.1"
-
-babylon@^6.17.0, babylon@^6.17.2:
-  version "6.17.4"
-  resolved "https://registry.yarnpkg.com/babylon/-/babylon-6.17.4.tgz#3e8b7402b88d22c3423e137a1577883b15ff869a"
+babylon@7.0.0-beta.42, babylon@^7.0.0-beta.40:
+  version "7.0.0-beta.42"
+  resolved "https://registry.yarnpkg.com/babylon/-/babylon-7.0.0-beta.42.tgz#67cfabcd4f3ec82999d29031ccdea89d0ba99657"
 
 balanced-match@^1.0.0:
   version "1.0.0"
@@ -226,10 +268,6 @@ concat-stream@^1.6.0:
     readable-stream "^2.2.2"
     typedarray "^0.0.6"
 
-core-js@^2.4.0:
-  version "2.4.1"
-  resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.4.1.tgz#4de911e667b0eae9124e34254b53aea6fc618d3e"
-
 core-util-is@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
@@ -247,12 +285,6 @@ debug@2.6.0:
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.0.tgz#bc596bcabe7617f11d9fa15361eded5608b8499b"
   dependencies:
     ms "0.7.2"
-
-debug@^2.2.0:
-  version "2.6.8"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.8.tgz#e731531ca2ede27d188222427da17821d68ff4fc"
-  dependencies:
-    ms "2.0.0"
 
 debug@^3.1.0:
   version "3.1.0"
@@ -294,7 +326,7 @@ eslint-rule-composer@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/eslint-rule-composer/-/eslint-rule-composer-0.1.1.tgz#479dfd4e93d7f2777499a35ce9be76403c8e982a"
 
-eslint-scope@^3.7.1:
+eslint-scope@^3.7.1, eslint-scope@~3.7.1:
   version "3.7.1"
   resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-3.7.1.tgz#3d63c3edfda02e06e01a452ad88caacc7cdcb6e8"
   dependencies:
@@ -452,13 +484,9 @@ glob@^7.0.3, glob@^7.0.5, glob@^7.1.2:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-globals@^11.0.1:
+globals@^11.0.1, globals@^11.1.0:
   version "11.4.0"
   resolved "https://registry.yarnpkg.com/globals/-/globals-11.4.0.tgz#b85c793349561c16076a3c13549238a27945f1bc"
-
-globals@^9.0.0:
-  version "9.18.0"
-  resolved "https://registry.yarnpkg.com/globals/-/globals-9.18.0.tgz#aa3896b3e69b487f17e31ed2143d69a8e30c2d8a"
 
 globby@^5.0.0:
   version "5.0.0"
@@ -593,6 +621,10 @@ js-yaml@^3.9.1:
   dependencies:
     argparse "^1.0.7"
     esprima "^4.0.0"
+
+jsesc@^2.5.1:
+  version "2.5.1"
+  resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-2.5.1.tgz#e421a2a8e20d6b0819df28908f782526b96dd1fe"
 
 json-schema-traverse@^0.3.0:
   version "0.3.1"
@@ -822,10 +854,6 @@ readable-stream@^2.2.2:
     string_decoder "~1.0.0"
     util-deprecate "~1.0.1"
 
-regenerator-runtime@^0.10.0:
-  version "0.10.5"
-  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz#336c3efc1220adcedda2c9fab67b5a7955a33658"
-
 regexpp@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/regexpp/-/regexpp-1.0.1.tgz#d857c3a741dce075c2848dcb019a0a975b190d43"
@@ -902,6 +930,10 @@ slice-ansi@1.0.0:
   dependencies:
     is-fullwidth-code-point "^2.0.0"
 
+source-map@^0.5.0:
+  version "0.5.7"
+  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.7.tgz#8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc"
+
 sprintf-js@~1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
@@ -976,9 +1008,13 @@ tmp@^0.0.33:
   dependencies:
     os-tmpdir "~1.0.2"
 
-to-fast-properties@^1.0.1:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/to-fast-properties/-/to-fast-properties-1.0.3.tgz#b83571fa4d8c25b82e231b06e3a3055de4ca1a47"
+to-fast-properties@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/to-fast-properties/-/to-fast-properties-2.0.0.tgz#dc5e698cbd079265bc73e0377681a4e4e83f616e"
+
+trim-right@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/trim-right/-/trim-right-1.0.1.tgz#cb2e1203067e0c8de1f614094b9fe45704ea6003"
 
 tryit@^1.0.1:
   version "1.0.3"


### PR DESCRIPTION
Depends on https://github.com/babel/eslint-plugin-babel/pull/138.

Until acorn is bumped in ESLint (ref: https://github.com/eslint/eslint/issues/9662), this allows the JSX fragment shorthand syntax to not trip the `quotes` rule.

Related babel-eslint thread:
https://github.com/babel/babel-eslint/issues/554