### PR TITLE
Add `space-infix-ops` rule with support for class properties. Fixes #58

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,8 @@ original ones as well!).
     "babel/quotes": 1,
     "babel/semi": 1,
     "babel/no-unused-expressions": 1,
-    "babel/valid-typeof": 1
+    "babel/valid-typeof": 1,
+    "babel/space-infix-ops": 1
   }
 }
 ```
@@ -53,6 +54,7 @@ Each rule corresponds to a core `eslint` rule, and has the same options.
 - `babel/semi`: doesn't fail when using `for await (let something of {})`. Includes class properties (🛠)
 - `babel/no-unused-expressions`: doesn't fail when using `do` expressions or [optional chaining](https://github.com/tc39/proposal-optional-chaining) (`a?.b()`).
 - `babel/valid-typeof`: doesn't complain when used with [BigInt](https://github.com/tc39/proposal-bigint) (`typeof BigInt(9007199254740991) === 'bigint'`).
+- `babel/space-infix-ops`: validates class properties (`class A { static a= 'a'; }` or `class A { b='b'` })
 
 #### Deprecated
 

--- a/index.js
+++ b/index.js
@@ -17,6 +17,7 @@ module.exports = {
     'quotes': require('./rules/quotes'),
     'semi': require('./rules/semi'),
     'valid-typeof': require('./rules/valid-typeof'),
+    'space-infix-ops': require('./rules/space-infix-ops'),
   },
   rulesConfig: {
     'array-bracket-spacing': 0,
@@ -34,5 +35,6 @@ module.exports = {
     'quotes': 0,
     'semi': 0,
     'valid-typeof': 0,
+    'space-infix-ops': 0,
   },
 };

--- a/rules/space-infix-ops.js
+++ b/rules/space-infix-ops.js
@@ -1,0 +1,178 @@
+/**
+ * @fileoverview Require spaces around infix operators
+ * @author Michael Ficarra
+ */
+"use strict";
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+module.exports = {
+    meta: {
+        type: "layout",
+
+        docs: {
+            description: "require spacing around infix operators",
+            category: "Stylistic Issues",
+            recommended: false,
+            url: "https://eslint.org/docs/rules/space-infix-ops"
+        },
+
+        fixable: "whitespace",
+
+        schema: [
+            {
+                type: "object",
+                properties: {
+                    int32Hint: {
+                        type: "boolean"
+                    }
+                },
+                additionalProperties: false
+            }
+        ]
+    },
+
+    create(context) {
+        const int32Hint = context.options[0] ? context.options[0].int32Hint === true : false;
+        const sourceCode = context.getSourceCode();
+
+        /**
+         * Returns the first token which violates the rule
+         * @param {ASTNode} left - The left node of the main node
+         * @param {ASTNode} right - The right node of the main node
+         * @param {string} op - The operator of the main node
+         * @returns {Object} The violator token or null
+         * @private
+         */
+        function getFirstNonSpacedToken(left, right, op) {
+            const operator = sourceCode.getFirstTokenBetween(left, right, token => token.value === op);
+            const prev = sourceCode.getTokenBefore(operator);
+            const next = sourceCode.getTokenAfter(operator);
+
+            if (!sourceCode.isSpaceBetweenTokens(prev, operator) || !sourceCode.isSpaceBetweenTokens(operator, next)) {
+                return operator;
+            }
+
+            return null;
+        }
+
+        /**
+         * Reports an AST node as a rule violation
+         * @param {ASTNode} mainNode - The node to report
+         * @param {Object} culpritToken - The token which has a problem
+         * @returns {void}
+         * @private
+         */
+        function report(mainNode, culpritToken) {
+            context.report({
+                node: mainNode,
+                loc: culpritToken.loc.start,
+                message: "Operator '{{operator}}' must be spaced.",
+                data: {
+                    operator: culpritToken.value
+                },
+                fix(fixer) {
+                    const previousToken = sourceCode.getTokenBefore(culpritToken);
+                    const afterToken = sourceCode.getTokenAfter(culpritToken);
+                    let fixString = "";
+
+                    if (culpritToken.range[0] - previousToken.range[1] === 0) {
+                        fixString = " ";
+                    }
+
+                    fixString += culpritToken.value;
+
+                    if (afterToken.range[0] - culpritToken.range[1] === 0) {
+                        fixString += " ";
+                    }
+
+                    return fixer.replaceText(culpritToken, fixString);
+                }
+            });
+        }
+
+        /**
+         * Check if the node is binary then report
+         * @param {ASTNode} node node to evaluate
+         * @returns {void}
+         * @private
+         */
+        function checkBinary(node) {
+            const leftNode = (node.left.typeAnnotation) ? node.left.typeAnnotation : node.left;
+            const rightNode = node.right;
+
+            // search for = in AssignmentPattern nodes
+            const operator = node.operator || "=";
+
+            const nonSpacedNode = getFirstNonSpacedToken(leftNode, rightNode, operator);
+
+            if (nonSpacedNode) {
+                if (!(int32Hint && sourceCode.getText(node).endsWith("|0"))) {
+                    report(node, nonSpacedNode);
+                }
+            }
+        }
+
+        /**
+         * Check if the node is conditional
+         * @param {ASTNode} node node to evaluate
+         * @returns {void}
+         * @private
+         */
+        function checkConditional(node) {
+            const nonSpacedConsequesntNode = getFirstNonSpacedToken(node.test, node.consequent, "?");
+            const nonSpacedAlternateNode = getFirstNonSpacedToken(node.consequent, node.alternate, ":");
+
+            if (nonSpacedConsequesntNode) {
+                report(node, nonSpacedConsequesntNode);
+            } else if (nonSpacedAlternateNode) {
+                report(node, nonSpacedAlternateNode);
+            }
+        }
+
+        /**
+         * Check if the node is a variable
+         * @param {ASTNode} node node to evaluate
+         * @returns {void}
+         * @private
+         */
+        function checkVar(node) {
+            const leftNode = (node.id.typeAnnotation) ? node.id.typeAnnotation : node.id;
+            const rightNode = node.init;
+
+            if (rightNode) {
+                const nonSpacedNode = getFirstNonSpacedToken(leftNode, rightNode, "=");
+
+                if (nonSpacedNode) {
+                    report(node, nonSpacedNode);
+                }
+            }
+        }
+
+        function checkProperty(node) {
+            const leftNode = node.typeAnnotation ? node.typeAnnotation : node.key;
+            const rightNode = node.value;
+
+            if (rightNode) {
+                const nonSpacedNode = getFirstNonSpacedToken(leftNode, rightNode, "=");
+
+                if (nonSpacedNode) {
+                    report(node, nonSpacedNode);
+                }
+            }
+        }
+
+        return {
+            AssignmentExpression: checkBinary,
+            AssignmentPattern: checkBinary,
+            BinaryExpression: checkBinary,
+            LogicalExpression: checkBinary,
+            ConditionalExpression: checkConditional,
+            VariableDeclarator: checkVar,
+            ClassProperty: checkProperty
+        };
+
+    }
+};

--- a/tests/fixtures/fixture-parser.js
+++ b/tests/fixtures/fixture-parser.js
@@ -1,0 +1,16 @@
+"use strict";
+
+const path = require("path");
+
+/**
+ * Gets the path to the specified parser.
+ *
+ * @param {string[]} arguments - The path containing the parser.
+ * @returns {string} The path to the specified parser.
+ */
+module.exports = function parser() {
+    const parts = Array.from(arguments);
+    const name = parts.pop();
+
+    return path.resolve(__dirname, "parsers", parts.join(path.sep), `${name}.js`);
+};

--- a/tests/fixtures/parsers/type-annotations/class-property-type-annotation-no-space.js
+++ b/tests/fixtures/parsers/type-annotations/class-property-type-annotation-no-space.js
@@ -1,0 +1,405 @@
+/**
+ * Source code:
+ * class A { foo: Bar=bar }
+ */
+
+exports.parse = () => ({
+    "type": "Program",
+    "start": 0,
+    "end": 24,
+    "loc": {
+    "start": {
+      "line": 1,
+        "column": 0
+    },
+    "end": {
+      "line": 1,
+        "column": 24
+    }
+  },
+    "range": [
+    0,
+    24
+  ],
+    "comments": [],
+    "tokens": [
+    {
+      "type": "Keyword",
+      "value": "class",
+      "start": 0,
+      "end": 5,
+      "loc": {
+        "start": {
+          "line": 1,
+          "column": 0
+        },
+        "end": {
+          "line": 1,
+          "column": 5
+        }
+      },
+      "range": [
+        0,
+        5
+      ]
+    },
+    {
+      "type": "Identifier",
+      "value": "A",
+      "start": 6,
+      "end": 7,
+      "loc": {
+        "start": {
+          "line": 1,
+          "column": 6
+        },
+        "end": {
+          "line": 1,
+          "column": 7
+        }
+      },
+      "range": [
+        6,
+        7
+      ]
+    },
+    {
+      "type": "Punctuator",
+      "value": "{",
+      "start": 8,
+      "end": 9,
+      "loc": {
+        "start": {
+          "line": 1,
+          "column": 8
+        },
+        "end": {
+          "line": 1,
+          "column": 9
+        }
+      },
+      "range": [
+        8,
+        9
+      ]
+    },
+    {
+      "type": "Identifier",
+      "value": "foo",
+      "start": 10,
+      "end": 13,
+      "loc": {
+        "start": {
+          "line": 1,
+          "column": 10
+        },
+        "end": {
+          "line": 1,
+          "column": 13
+        }
+      },
+      "range": [
+        10,
+        13
+      ]
+    },
+    {
+      "type": "Punctuator",
+      "value": ":",
+      "start": 13,
+      "end": 14,
+      "loc": {
+        "start": {
+          "line": 1,
+          "column": 13
+        },
+        "end": {
+          "line": 1,
+          "column": 14
+        }
+      },
+      "range": [
+        13,
+        14
+      ]
+    },
+    {
+      "type": "Identifier",
+      "value": "Bar",
+      "start": 15,
+      "end": 18,
+      "loc": {
+        "start": {
+          "line": 1,
+          "column": 15
+        },
+        "end": {
+          "line": 1,
+          "column": 18
+        }
+      },
+      "range": [
+        15,
+        18
+      ]
+    },
+    {
+      "type": "Punctuator",
+      "value": "=",
+      "start": 18,
+      "end": 19,
+      "loc": {
+        "start": {
+          "line": 1,
+          "column": 18
+        },
+        "end": {
+          "line": 1,
+          "column": 19
+        }
+      },
+      "range": [
+        18,
+        19
+      ]
+    },
+    {
+      "type": "Identifier",
+      "value": "bar",
+      "start": 19,
+      "end": 22,
+      "loc": {
+        "start": {
+          "line": 1,
+          "column": 19
+        },
+        "end": {
+          "line": 1,
+          "column": 22
+        }
+      },
+      "range": [
+        19,
+        22
+      ]
+    },
+    {
+      "type": "Punctuator",
+      "value": "}",
+      "start": 23,
+      "end": 24,
+      "loc": {
+        "start": {
+          "line": 1,
+          "column": 23
+        },
+        "end": {
+          "line": 1,
+          "column": 24
+        }
+      },
+      "range": [
+        23,
+        24
+      ]
+    }
+  ],
+    "sourceType": "script",
+    "body": [
+    {
+      "type": "ClassDeclaration",
+      "start": 0,
+      "end": 24,
+      "loc": {
+        "start": {
+          "line": 1,
+          "column": 0
+        },
+        "end": {
+          "line": 1,
+          "column": 24
+        }
+      },
+      "range": [
+        0,
+        24
+      ],
+      "id": {
+        "type": "Identifier",
+        "start": 6,
+        "end": 7,
+        "loc": {
+          "start": {
+            "line": 1,
+            "column": 6
+          },
+          "end": {
+            "line": 1,
+            "column": 7
+          },
+          "identifierName": "A"
+        },
+        "range": [
+          6,
+          7
+        ],
+        "name": "A",
+        "_babelType": "Identifier"
+      },
+      "superClass": null,
+      "body": {
+        "type": "ClassBody",
+        "start": 8,
+        "end": 24,
+        "loc": {
+          "start": {
+            "line": 1,
+            "column": 8
+          },
+          "end": {
+            "line": 1,
+            "column": 24
+          }
+        },
+        "range": [
+          8,
+          24
+        ],
+        "body": [
+          {
+            "type": "ClassProperty",
+            "start": 10,
+            "end": 22,
+            "loc": {
+              "start": {
+                "line": 1,
+                "column": 10
+              },
+              "end": {
+                "line": 1,
+                "column": 22
+              }
+            },
+            "range": [
+              10,
+              22
+            ],
+            "static": false,
+            "key": {
+              "type": "Identifier",
+              "start": 10,
+              "end": 13,
+              "loc": {
+                "start": {
+                  "line": 1,
+                  "column": 10
+                },
+                "end": {
+                  "line": 1,
+                  "column": 13
+                },
+                "identifierName": "foo"
+              },
+              "range": [
+                10,
+                13
+              ],
+              "name": "foo",
+              "_babelType": "Identifier"
+            },
+            "computed": false,
+            "variance": null,
+            "typeAnnotation": {
+              "type": "TypeAnnotation",
+              "start": 13,
+              "end": 18,
+              "loc": {
+                "start": {
+                  "line": 1,
+                  "column": 13
+                },
+                "end": {
+                  "line": 1,
+                  "column": 18
+                }
+              },
+              "range": [
+                13,
+                18
+              ],
+              "typeAnnotation": {
+                "type": "GenericTypeAnnotation",
+                "start": 15,
+                "end": 18,
+                "loc": {
+                  "start": {
+                    "line": 1,
+                    "column": 15
+                  },
+                  "end": {
+                    "line": 1,
+                    "column": 18
+                  }
+                },
+                "range": [
+                  15,
+                  18
+                ],
+                "typeParameters": null,
+                "id": {
+                  "type": "Identifier",
+                  "start": 15,
+                  "end": 18,
+                  "loc": {
+                    "start": {
+                      "line": 1,
+                      "column": 15
+                    },
+                    "end": {
+                      "line": 1,
+                      "column": 18
+                    },
+                    "identifierName": "Bar"
+                  },
+                  "range": [
+                    15,
+                    18
+                  ],
+                  "name": "Bar",
+                  "_babelType": "Identifier"
+                },
+                "_babelType": "GenericTypeAnnotation"
+              },
+              "_babelType": "TypeAnnotation"
+            },
+            "value": {
+              "type": "Identifier",
+              "start": 19,
+              "end": 22,
+              "loc": {
+                "start": {
+                  "line": 1,
+                  "column": 19
+                },
+                "end": {
+                  "line": 1,
+                  "column": 22
+                },
+                "identifierName": "bar"
+              },
+              "range": [
+                19,
+                22
+              ],
+              "name": "bar",
+              "_babelType": "Identifier"
+            },
+            "_babelType": "ClassProperty"
+          }
+        ],
+        "_babelType": "ClassBody"
+      },
+      "_babelType": "ClassDeclaration"
+    }
+  ]
+});

--- a/tests/fixtures/parsers/type-annotations/class-property-type-annotation.js
+++ b/tests/fixtures/parsers/type-annotations/class-property-type-annotation.js
@@ -1,0 +1,382 @@
+/**
+ * Source code:
+ * class A { foo: Bar = bar }
+ */
+
+exports.parse = () => ({
+  "type": "Program",
+  "start": 0,
+  "end": 27,
+  "loc": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 1,
+      "column": 27
+    }
+  },
+  "range": [
+    0,
+    27
+  ],
+  "comments": [],
+  "tokens": [
+    {
+      "type": "Keyword",
+      "value": "class",
+      "start": 0,
+      "end": 5,
+      "loc": {
+        "start": {
+          "line": 1,
+          "column": 0
+        },
+        "end": {
+          "line": 1,
+          "column": 5
+        }
+      },
+      "range": [
+        0,
+        5
+      ]
+    },
+    {
+      "type": "Identifier",
+      "value": "A",
+      "start": 6,
+      "end": 7,
+      "loc": {
+        "start": {
+          "line": 1,
+          "column": 6
+        },
+        "end": {
+          "line": 1,
+          "column": 7
+        }
+      },
+      "range": [
+        6,
+        7
+      ]
+    },
+    {
+      "type": "Punctuator",
+      "value": "{",
+      "start": 8,
+      "end": 9,
+      "loc": {
+        "start": {
+          "line": 1,
+          "column": 8
+        },
+        "end": {
+          "line": 1,
+          "column": 9
+        }
+      },
+      "range": [
+        8,
+        9
+      ]
+    },
+    {
+      "type": "Identifier",
+      "value": "foo",
+      "start": 10,
+      "end": 13,
+      "loc": {
+        "start": {
+          "line": 1,
+          "column": 10
+        },
+        "end": {
+          "line": 1,
+          "column": 13
+        }
+      },
+      "range": [
+        10,
+        13
+      ]
+    },
+    {
+      "type": "Punctuator",
+      "value": ":",
+      "start": 13,
+      "end": 14,
+      "loc": {
+        "start": {
+          "line": 1,
+          "column": 13
+        },
+        "end": {
+          "line": 1,
+          "column": 14
+        }
+      },
+      "range": [
+        13,
+        14
+      ]
+    },
+    {
+      "type": "Identifier",
+      "value": "number",
+      "start": 15,
+      "end": 21,
+      "loc": {
+        "start": {
+          "line": 1,
+          "column": 15
+        },
+        "end": {
+          "line": 1,
+          "column": 21
+        }
+      },
+      "range": [
+        15,
+        21
+      ]
+    },
+    {
+      "type": "Punctuator",
+      "value": "=",
+      "start": 22,
+      "end": 23,
+      "loc": {
+        "start": {
+          "line": 1,
+          "column": 22
+        },
+        "end": {
+          "line": 1,
+          "column": 23
+        }
+      },
+      "range": [
+        22,
+        23
+      ]
+    },
+    {
+      "type": "Numeric",
+      "value": "1",
+      "start": 24,
+      "end": 25,
+      "loc": {
+        "start": {
+          "line": 1,
+          "column": 24
+        },
+        "end": {
+          "line": 1,
+          "column": 25
+        }
+      },
+      "range": [
+        24,
+        25
+      ]
+    },
+    {
+      "type": "Punctuator",
+      "value": "}",
+      "start": 26,
+      "end": 27,
+      "loc": {
+        "start": {
+          "line": 1,
+          "column": 26
+        },
+        "end": {
+          "line": 1,
+          "column": 27
+        }
+      },
+      "range": [
+        26,
+        27
+      ]
+    }
+  ],
+  "sourceType": "script",
+  "body": [
+    {
+      "type": "ClassDeclaration",
+      "start": 0,
+      "end": 27,
+      "loc": {
+        "start": {
+          "line": 1,
+          "column": 0
+        },
+        "end": {
+          "line": 1,
+          "column": 27
+        }
+      },
+      "range": [
+        0,
+        27
+      ],
+      "id": {
+        "type": "Identifier",
+        "start": 6,
+        "end": 7,
+        "loc": {
+          "start": {
+            "line": 1,
+            "column": 6
+          },
+          "end": {
+            "line": 1,
+            "column": 7
+          },
+          "identifierName": "A"
+        },
+        "range": [
+          6,
+          7
+        ],
+        "name": "A",
+        "_babelType": "Identifier"
+      },
+      "superClass": null,
+      "body": {
+        "type": "ClassBody",
+        "start": 8,
+        "end": 27,
+        "loc": {
+          "start": {
+            "line": 1,
+            "column": 8
+          },
+          "end": {
+            "line": 1,
+            "column": 27
+          }
+        },
+        "range": [
+          8,
+          27
+        ],
+        "body": [
+          {
+            "type": "ClassProperty",
+            "start": 10,
+            "end": 25,
+            "loc": {
+              "start": {
+                "line": 1,
+                "column": 10
+              },
+              "end": {
+                "line": 1,
+                "column": 25
+              }
+            },
+            "range": [
+              10,
+              25
+            ],
+            "static": false,
+            "key": {
+              "type": "Identifier",
+              "start": 10,
+              "end": 13,
+              "loc": {
+                "start": {
+                  "line": 1,
+                  "column": 10
+                },
+                "end": {
+                  "line": 1,
+                  "column": 13
+                },
+                "identifierName": "foo"
+              },
+              "range": [
+                10,
+                13
+              ],
+              "name": "foo",
+              "_babelType": "Identifier"
+            },
+            "computed": false,
+            "variance": null,
+            "typeAnnotation": {
+              "type": "TypeAnnotation",
+              "start": 13,
+              "end": 21,
+              "loc": {
+                "start": {
+                  "line": 1,
+                  "column": 13
+                },
+                "end": {
+                  "line": 1,
+                  "column": 21
+                }
+              },
+              "range": [
+                13,
+                21
+              ],
+              "typeAnnotation": {
+                "type": "NumberTypeAnnotation",
+                "start": 15,
+                "end": 21,
+                "loc": {
+                  "start": {
+                    "line": 1,
+                    "column": 15
+                  },
+                  "end": {
+                    "line": 1,
+                    "column": 21
+                  }
+                },
+                "range": [
+                  15,
+                  21
+                ],
+                "_babelType": "NumberTypeAnnotation"
+              },
+              "_babelType": "TypeAnnotation"
+            },
+            "value": {
+              "type": "Literal",
+              "start": 24,
+              "end": 25,
+              "loc": {
+                "start": {
+                  "line": 1,
+                  "column": 24
+                },
+                "end": {
+                  "line": 1,
+                  "column": 25
+                }
+              },
+              "range": [
+                24,
+                25
+              ],
+              "value": 1,
+              "raw": "1",
+              "_babelType": "Literal"
+            },
+            "_babelType": "ClassProperty"
+          }
+        ],
+        "_babelType": "ClassBody"
+      },
+      "_babelType": "ClassDeclaration"
+    }
+  ]
+});

--- a/tests/fixtures/parsers/type-annotations/function-declaration-type-annotation-no-space.js
+++ b/tests/fixtures/parsers/type-annotations/function-declaration-type-annotation-no-space.js
@@ -1,0 +1,486 @@
+/**
+ * Source code:
+ * function foo(a: number=0): Foo { }
+ */
+
+exports.parse = () => ({
+    "type": "Program",
+    "range": [
+        0,
+        34
+    ],
+    "loc": {
+        "start": {
+            "line": 1,
+            "column": 0
+        },
+        "end": {
+            "line": 1,
+            "column": 34
+        }
+    },
+    "body": [
+        {
+            "type": "FunctionDeclaration",
+            "range": [
+                0,
+                34
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 0
+                },
+                "end": {
+                    "line": 1,
+                    "column": 34
+                }
+            },
+            "id": {
+                "type": "Identifier",
+                "range": [
+                    9,
+                    12
+                ],
+                "loc": {
+                    "start": {
+                        "line": 1,
+                        "column": 9
+                    },
+                    "end": {
+                        "line": 1,
+                        "column": 12
+                    }
+                },
+                "name": "foo"
+            },
+            "generator": false,
+            "expression": false,
+            "async": false,
+            "params": [
+                {
+                    "type": "AssignmentPattern",
+                    "range": [
+                        13,
+                        24
+                    ],
+                    "loc": {
+                        "start": {
+                            "line": 1,
+                            "column": 13
+                        },
+                        "end": {
+                            "line": 1,
+                            "column": 24
+                        }
+                    },
+                    "left": {
+                        "type": "Identifier",
+                        "range": [
+                            13,
+                            14
+                        ],
+                        "loc": {
+                            "start": {
+                                "line": 1,
+                                "column": 13
+                            },
+                            "end": {
+                                "line": 1,
+                                "column": 14
+                            }
+                        },
+                        "name": "a",
+                        "typeAnnotation": {
+                            "type": "TypeAnnotation",
+                            "loc": {
+                                "start": {
+                                    "line": 1,
+                                    "column": 16
+                                },
+                                "end": {
+                                    "line": 1,
+                                    "column": 22
+                                }
+                            },
+                            "range": [
+                                16,
+                                22
+                            ],
+                            "typeAnnotation": {
+                                "type": "NumberKeyword",
+                                "range": [
+                                    16,
+                                    22
+                                ],
+                                "loc": {
+                                    "start": {
+                                        "line": 1,
+                                        "column": 16
+                                    },
+                                    "end": {
+                                        "line": 1,
+                                        "column": 22
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "right": {
+                        "type": "Literal",
+                        "range": [
+                            23,
+                            24
+                        ],
+                        "loc": {
+                            "start": {
+                                "line": 1,
+                                "column": 23
+                            },
+                            "end": {
+                                "line": 1,
+                                "column": 24
+                            }
+                        },
+                        "value": 0,
+                        "raw": "0"
+                    }
+                }
+            ],
+            "body": {
+                "type": "BlockStatement",
+                "range": [
+                    31,
+                    34
+                ],
+                "loc": {
+                    "start": {
+                        "line": 1,
+                        "column": 31
+                    },
+                    "end": {
+                        "line": 1,
+                        "column": 34
+                    }
+                },
+                "body": []
+            },
+            "returnType": {
+                "type": "TypeAnnotation",
+                "loc": {
+                    "start": {
+                        "line": 1,
+                        "column": 27
+                    },
+                    "end": {
+                        "line": 1,
+                        "column": 30
+                    }
+                },
+                "range": [
+                    27,
+                    30
+                ],
+                "typeAnnotation": {
+                    "type": "TypeReference",
+                    "range": [
+                        27,
+                        30
+                    ],
+                    "loc": {
+                        "start": {
+                            "line": 1,
+                            "column": 27
+                        },
+                        "end": {
+                            "line": 1,
+                            "column": 30
+                        }
+                    },
+                    "typeName": {
+                        "type": "Identifier",
+                        "range": [
+                            27,
+                            30
+                        ],
+                        "loc": {
+                            "start": {
+                                "line": 1,
+                                "column": 27
+                            },
+                            "end": {
+                                "line": 1,
+                                "column": 30
+                            }
+                        },
+                        "name": "Foo"
+                    }
+                }
+            }
+        }
+    ],
+    "sourceType": "script",
+    "tokens": [
+        {
+            "type": "Keyword",
+            "value": "function",
+            "start": 0,
+            "end": 8,
+            "range": [
+                0,
+                8
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 0
+                },
+                "end": {
+                    "line": 1,
+                    "column": 8
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "foo",
+            "start": 9,
+            "end": 12,
+            "range": [
+                9,
+                12
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 9
+                },
+                "end": {
+                    "line": 1,
+                    "column": 12
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "(",
+            "start": 12,
+            "end": 13,
+            "range": [
+                12,
+                13
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 12
+                },
+                "end": {
+                    "line": 1,
+                    "column": 13
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "a",
+            "start": 13,
+            "end": 14,
+            "range": [
+                13,
+                14
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 13
+                },
+                "end": {
+                    "line": 1,
+                    "column": 14
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": ":",
+            "start": 14,
+            "end": 15,
+            "range": [
+                14,
+                15
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 14
+                },
+                "end": {
+                    "line": 1,
+                    "column": 15
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "number",
+            "start": 16,
+            "end": 22,
+            "range": [
+                16,
+                22
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 16
+                },
+                "end": {
+                    "line": 1,
+                    "column": 22
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "=",
+            "start": 22,
+            "end": 23,
+            "range": [
+                22,
+                23
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 22
+                },
+                "end": {
+                    "line": 1,
+                    "column": 23
+                }
+            }
+        },
+        {
+            "type": "Numeric",
+            "value": "0",
+            "start": 23,
+            "end": 24,
+            "range": [
+                23,
+                24
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 23
+                },
+                "end": {
+                    "line": 1,
+                    "column": 24
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": ")",
+            "start": 24,
+            "end": 25,
+            "range": [
+                24,
+                25
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 24
+                },
+                "end": {
+                    "line": 1,
+                    "column": 25
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": ":",
+            "start": 25,
+            "end": 26,
+            "range": [
+                25,
+                26
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 25
+                },
+                "end": {
+                    "line": 1,
+                    "column": 26
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "Foo",
+            "start": 27,
+            "end": 30,
+            "range": [
+                27,
+                30
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 27
+                },
+                "end": {
+                    "line": 1,
+                    "column": 30
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "{",
+            "start": 31,
+            "end": 32,
+            "range": [
+                31,
+                32
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 31
+                },
+                "end": {
+                    "line": 1,
+                    "column": 32
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "}",
+            "start": 33,
+            "end": 34,
+            "range": [
+                33,
+                34
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 33
+                },
+                "end": {
+                    "line": 1,
+                    "column": 34
+                }
+            }
+        }
+    ],
+    "comments": []
+});

--- a/tests/fixtures/parsers/type-annotations/function-expression-type-annotation.js
+++ b/tests/fixtures/parsers/type-annotations/function-expression-type-annotation.js
@@ -1,0 +1,584 @@
+/**
+ * Source code:
+ * const foo = function(a: number = 0): Bar { };
+ */
+
+exports.parse = () => ({
+  "type": "Program",
+  "range": [
+    0,
+    45
+  ],
+  "loc": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 1,
+      "column": 45
+    }
+  },
+  "body": [
+    {
+      "type": "VariableDeclaration",
+      "range": [
+        0,
+        45
+      ],
+      "loc": {
+        "start": {
+          "line": 1,
+          "column": 0
+        },
+        "end": {
+          "line": 1,
+          "column": 45
+        }
+      },
+      "declarations": [
+        {
+          "type": "VariableDeclarator",
+          "range": [
+            6,
+            44
+          ],
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 6
+            },
+            "end": {
+              "line": 1,
+              "column": 44
+            }
+          },
+          "id": {
+            "type": "Identifier",
+            "range": [
+              6,
+              9
+            ],
+            "loc": {
+              "start": {
+                "line": 1,
+                "column": 6
+              },
+              "end": {
+                "line": 1,
+                "column": 9
+              }
+            },
+            "name": "foo"
+          },
+          "init": {
+            "type": "FunctionExpression",
+            "range": [
+              12,
+              44
+            ],
+            "loc": {
+              "start": {
+                "line": 1,
+                "column": 12
+              },
+              "end": {
+                "line": 1,
+                "column": 44
+              }
+            },
+            "id": null,
+            "generator": false,
+            "params": [
+              {
+                "type": "AssignmentPattern",
+                "range": [
+                  21,
+                  34
+                ],
+                "loc": {
+                  "start": {
+                    "line": 1,
+                    "column": 21
+                  },
+                  "end": {
+                    "line": 1,
+                    "column": 34
+                  }
+                },
+                "left": {
+                  "type": "Identifier",
+                  "range": [
+                    21,
+                    22
+                  ],
+                  "loc": {
+                    "start": {
+                      "line": 1,
+                      "column": 21
+                    },
+                    "end": {
+                      "line": 1,
+                      "column": 22
+                    }
+                  },
+                  "name": "a",
+                  "typeAnnotation": {
+                    "type": "TypeAnnotation",
+                    "loc": {
+                      "start": {
+                        "line": 1,
+                        "column": 24
+                      },
+                      "end": {
+                        "line": 1,
+                        "column": 30
+                      }
+                    },
+                    "range": [
+                      24,
+                      30
+                    ],
+                    "typeAnnotation": {
+                      "type": "NumberKeyword",
+                      "range": [
+                        24,
+                        30
+                      ],
+                      "loc": {
+                        "start": {
+                          "line": 1,
+                          "column": 24
+                        },
+                        "end": {
+                          "line": 1,
+                          "column": 30
+                        }
+                      }
+                    }
+                  }
+                },
+                "right": {
+                  "type": "Literal",
+                  "range": [
+                    33,
+                    34
+                  ],
+                  "loc": {
+                    "start": {
+                      "line": 1,
+                      "column": 33
+                    },
+                    "end": {
+                      "line": 1,
+                      "column": 34
+                    }
+                  },
+                  "value": 0,
+                  "raw": "0"
+                }
+              }
+            ],
+            "body": {
+              "type": "BlockStatement",
+              "range": [
+                41,
+                44
+              ],
+              "loc": {
+                "start": {
+                  "line": 1,
+                  "column": 41
+                },
+                "end": {
+                  "line": 1,
+                  "column": 44
+                }
+              },
+              "body": []
+            },
+            "async": false,
+            "expression": false,
+            "returnType": {
+              "type": "TypeAnnotation",
+              "loc": {
+                "start": {
+                  "line": 1,
+                  "column": 37
+                },
+                "end": {
+                  "line": 1,
+                  "column": 40
+                }
+              },
+              "range": [
+                37,
+                40
+              ],
+              "typeAnnotation": {
+                "type": "TypeReference",
+                "range": [
+                  37,
+                  40
+                ],
+                "loc": {
+                  "start": {
+                    "line": 1,
+                    "column": 37
+                  },
+                  "end": {
+                    "line": 1,
+                    "column": 40
+                  }
+                },
+                "typeName": {
+                  "type": "Identifier",
+                  "range": [
+                    37,
+                    40
+                  ],
+                  "loc": {
+                    "start": {
+                      "line": 1,
+                      "column": 37
+                    },
+                    "end": {
+                      "line": 1,
+                      "column": 40
+                    }
+                  },
+                  "name": "Bar"
+                }
+              }
+            }
+          }
+        }
+      ],
+      "kind": "const"
+    }
+  ],
+  "sourceType": "script",
+  "tokens": [
+    {
+      "type": "Keyword",
+      "value": "const",
+      "start": 0,
+      "end": 5,
+      "range": [
+        0,
+        5
+      ],
+      "loc": {
+        "start": {
+          "line": 1,
+          "column": 0
+        },
+        "end": {
+          "line": 1,
+          "column": 5
+        }
+      }
+    },
+    {
+      "type": "Identifier",
+      "value": "foo",
+      "start": 6,
+      "end": 9,
+      "range": [
+        6,
+        9
+      ],
+      "loc": {
+        "start": {
+          "line": 1,
+          "column": 6
+        },
+        "end": {
+          "line": 1,
+          "column": 9
+        }
+      }
+    },
+    {
+      "type": "Punctuator",
+      "value": "=",
+      "start": 10,
+      "end": 11,
+      "range": [
+        10,
+        11
+      ],
+      "loc": {
+        "start": {
+          "line": 1,
+          "column": 10
+        },
+        "end": {
+          "line": 1,
+          "column": 11
+        }
+      }
+    },
+    {
+      "type": "Keyword",
+      "value": "function",
+      "start": 12,
+      "end": 20,
+      "range": [
+        12,
+        20
+      ],
+      "loc": {
+        "start": {
+          "line": 1,
+          "column": 12
+        },
+        "end": {
+          "line": 1,
+          "column": 20
+        }
+      }
+    },
+    {
+      "type": "Punctuator",
+      "value": "(",
+      "start": 20,
+      "end": 21,
+      "range": [
+        20,
+        21
+      ],
+      "loc": {
+        "start": {
+          "line": 1,
+          "column": 20
+        },
+        "end": {
+          "line": 1,
+          "column": 21
+        }
+      }
+    },
+    {
+      "type": "Identifier",
+      "value": "a",
+      "start": 21,
+      "end": 22,
+      "range": [
+        21,
+        22
+      ],
+      "loc": {
+        "start": {
+          "line": 1,
+          "column": 21
+        },
+        "end": {
+          "line": 1,
+          "column": 22
+        }
+      }
+    },
+    {
+      "type": "Punctuator",
+      "value": ":",
+      "start": 22,
+      "end": 23,
+      "range": [
+        22,
+        23
+      ],
+      "loc": {
+        "start": {
+          "line": 1,
+          "column": 22
+        },
+        "end": {
+          "line": 1,
+          "column": 23
+        }
+      }
+    },
+    {
+      "type": "Identifier",
+      "value": "number",
+      "start": 24,
+      "end": 30,
+      "range": [
+        24,
+        30
+      ],
+      "loc": {
+        "start": {
+          "line": 1,
+          "column": 24
+        },
+        "end": {
+          "line": 1,
+          "column": 30
+        }
+      }
+    },
+    {
+      "type": "Punctuator",
+      "value": "=",
+      "start": 31,
+      "end": 32,
+      "range": [
+        31,
+        32
+      ],
+      "loc": {
+        "start": {
+          "line": 1,
+          "column": 31
+        },
+        "end": {
+          "line": 1,
+          "column": 32
+        }
+      }
+    },
+    {
+      "type": "Numeric",
+      "value": "0",
+      "start": 33,
+      "end": 34,
+      "range": [
+        33,
+        34
+      ],
+      "loc": {
+        "start": {
+          "line": 1,
+          "column": 33
+        },
+        "end": {
+          "line": 1,
+          "column": 34
+        }
+      }
+    },
+    {
+      "type": "Punctuator",
+      "value": ")",
+      "start": 34,
+      "end": 35,
+      "range": [
+        34,
+        35
+      ],
+      "loc": {
+        "start": {
+          "line": 1,
+          "column": 34
+        },
+        "end": {
+          "line": 1,
+          "column": 35
+        }
+      }
+    },
+    {
+      "type": "Punctuator",
+      "value": ":",
+      "start": 35,
+      "end": 36,
+      "range": [
+        35,
+        36
+      ],
+      "loc": {
+        "start": {
+          "line": 1,
+          "column": 35
+        },
+        "end": {
+          "line": 1,
+          "column": 36
+        }
+      }
+    },
+    {
+      "type": "Identifier",
+      "value": "Bar",
+      "start": 37,
+      "end": 40,
+      "range": [
+        37,
+        40
+      ],
+      "loc": {
+        "start": {
+          "line": 1,
+          "column": 37
+        },
+        "end": {
+          "line": 1,
+          "column": 40
+        }
+      }
+    },
+    {
+      "type": "Punctuator",
+      "value": "{",
+      "start": 41,
+      "end": 42,
+      "range": [
+        41,
+        42
+      ],
+      "loc": {
+        "start": {
+          "line": 1,
+          "column": 41
+        },
+        "end": {
+          "line": 1,
+          "column": 42
+        }
+      }
+    },
+    {
+      "type": "Punctuator",
+      "value": "}",
+      "start": 43,
+      "end": 44,
+      "range": [
+        43,
+        44
+      ],
+      "loc": {
+        "start": {
+          "line": 1,
+          "column": 43
+        },
+        "end": {
+          "line": 1,
+          "column": 44
+        }
+      }
+    },
+    {
+      "type": "Punctuator",
+      "value": ";",
+      "start": 44,
+      "end": 45,
+      "range": [
+        44,
+        45
+      ],
+      "loc": {
+        "start": {
+          "line": 1,
+          "column": 44
+        },
+        "end": {
+          "line": 1,
+          "column": 45
+        }
+      }
+    }
+  ],
+  "comments": []
+});

--- a/tests/fixtures/parsers/type-annotations/function-parameter-type-annotation.js
+++ b/tests/fixtures/parsers/type-annotations/function-parameter-type-annotation.js
@@ -1,0 +1,393 @@
+/**
+ * Source code:
+ * function foo(a: number = 0) { }
+ */
+
+exports.parse = () => ({
+      "type": "Program",
+      "loc": {
+        "source": null,
+        "start": {
+          "line": 1,
+          "column": 0
+        },
+        "end": {
+          "line": 1,
+          "column": 31
+        }
+      },
+      "range": [
+        0,
+        31
+      ],
+      "body": [
+        {
+          "type": "FunctionDeclaration",
+          "loc": {
+            "source": null,
+            "start": {
+              "line": 1,
+              "column": 0
+            },
+            "end": {
+              "line": 1,
+              "column": 31
+            }
+          },
+          "range": [
+            0,
+            31
+          ],
+          "id": {
+            "type": "Identifier",
+            "loc": {
+              "source": null,
+              "start": {
+                "line": 1,
+                "column": 9
+              },
+              "end": {
+                "line": 1,
+                "column": 12
+              }
+            },
+            "range": [
+              9,
+              12
+            ],
+            "name": "foo",
+            "typeAnnotation": null,
+            "optional": false
+          },
+          "params": [
+            {
+              "type": "Identifier",
+              "loc": {
+                "source": null,
+                "start": {
+                  "line": 1,
+                  "column": 13
+                },
+                "end": {
+                  "line": 1,
+                  "column": 22
+                }
+              },
+              "range": [
+                13,
+                22
+              ],
+              "name": "a",
+              "typeAnnotation": {
+                "type": "TypeAnnotation",
+                "loc": {
+                  "source": null,
+                  "start": {
+                    "line": 1,
+                    "column": 14
+                  },
+                  "end": {
+                    "line": 1,
+                    "column": 22
+                  }
+                },
+                "range": [
+                  14,
+                  22
+                ],
+                "typeAnnotation": {
+                  "type": "NumberTypeAnnotation",
+                  "loc": {
+                    "source": null,
+                    "start": {
+                      "line": 1,
+                      "column": 16
+                    },
+                    "end": {
+                      "line": 1,
+                      "column": 22
+                    }
+                  },
+                  "range": [
+                    16,
+                    22
+                  ]
+                }
+              },
+              "optional": false
+            }
+          ],
+          "defaults": [
+            {
+              "type": "Literal",
+              "loc": {
+                "source": null,
+                "start": {
+                  "line": 1,
+                  "column": 25
+                },
+                "end": {
+                  "line": 1,
+                  "column": 26
+                }
+              },
+              "range": [
+                25,
+                26
+              ],
+              "value": 0,
+              "raw": "0"
+            }
+          ],
+          "rest": null,
+          "body": {
+            "type": "BlockStatement",
+            "loc": {
+              "source": null,
+              "start": {
+                "line": 1,
+                "column": 28
+              },
+              "end": {
+                "line": 1,
+                "column": 31
+              }
+            },
+            "range": [
+              28,
+              31
+            ],
+            "body": []
+          },
+          "async": false,
+          "generator": false,
+          "expression": false,
+          "returnType": null,
+          "typeParameters": null
+        }
+      ],
+      "comments": [],
+      "errors": [],
+    "tokens": [
+        {
+          "type": "Keyword",
+          "value": "function",
+          "start": 0,
+          "end": 8,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 0
+            },
+            "end": {
+              "line": 1,
+              "column": 8
+            }
+          },
+          "range": [
+            0,
+            8
+          ]
+        },
+        {
+          "type": "Identifier",
+          "value": "foo",
+          "start": 9,
+          "end": 12,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 9
+            },
+            "end": {
+              "line": 1,
+              "column": 12
+            }
+          },
+          "range": [
+            9,
+            12
+          ]
+        },
+        {
+          "type": "Punctuator",
+          "value": "(",
+          "start": 12,
+          "end": 13,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 12
+            },
+            "end": {
+              "line": 1,
+              "column": 13
+            }
+          },
+          "range": [
+            12,
+            13
+          ]
+        },
+        {
+          "type": "Identifier",
+          "value": "a",
+          "start": 13,
+          "end": 14,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 13
+            },
+            "end": {
+              "line": 1,
+              "column": 14
+            }
+          },
+          "range": [
+            13,
+            14
+          ]
+        },
+        {
+          "type": "Punctuator",
+          "value": ":",
+          "start": 15,
+          "end": 16,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 15
+            },
+            "end": {
+              "line": 1,
+              "column": 16
+            }
+          },
+          "range": [
+            15,
+            16
+          ]
+        },
+        {
+          "type": "Identifier",
+          "value": "string",
+          "start": 16,
+          "end": 22,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 16
+            },
+            "end": {
+              "line": 1,
+              "column": 22
+            }
+          },
+          "range": [
+            16,
+            22
+          ]
+        },
+        {
+          "type": "Punctuator",
+          "value": "=",
+          "start": 24,
+          "end": 25,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 24
+            },
+            "end": {
+              "line": 1,
+              "column": 25
+            }
+          },
+          "range": [
+            24,
+            25
+          ]
+        },
+        {
+          "type": "Numeric",
+          "value": "0",
+          "start": 26,
+          "end": 27,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 26
+            },
+            "end": {
+              "line": 1,
+              "column": 27
+            }
+          },
+          "range": [
+            26,
+            27
+          ]
+        },
+        {
+          "type": "Punctuator",
+          "value": ")",
+          "start": 27,
+          "end": 28,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 27
+            },
+            "end": {
+              "line": 1,
+              "column": 28
+            }
+          },
+          "range": [
+            27,
+            28
+          ]
+        },
+        {
+          "type": "Punctuator",
+          "value": "{",
+          "start": 29,
+          "end": 30,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 29
+            },
+            "end": {
+              "line": 1,
+              "column": 30
+            }
+          },
+          "range": [
+            29,
+            30
+          ]
+        },
+        {
+          "type": "Punctuator",
+          "value": "}",
+          "start": 31,
+          "end": 32,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 31
+            },
+            "end": {
+              "line": 1,
+              "column": 32
+            }
+          },
+          "range": [
+            31,
+            32
+          ]
+        }
+      ]
+});

--- a/tests/fixtures/parsers/type-annotations/function-return-type-annotation.js
+++ b/tests/fixtures/parsers/type-annotations/function-return-type-annotation.js
@@ -1,0 +1,297 @@
+/**
+ * Source code:
+ * function foo(): Bar { }
+ */
+
+exports.parse = () => ({
+    "type": "Program",
+    "range": [
+        0,
+        23
+    ],
+    "loc": {
+        "start": {
+            "line": 1,
+            "column": 0
+        },
+        "end": {
+            "line": 1,
+            "column": 23
+        }
+    },
+    "body": [
+        {
+            "type": "FunctionDeclaration",
+            "range": [
+                0,
+                23
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 0
+                },
+                "end": {
+                    "line": 1,
+                    "column": 23
+                }
+            },
+            "id": {
+                "type": "Identifier",
+                "range": [
+                    9,
+                    12
+                ],
+                "loc": {
+                    "start": {
+                        "line": 1,
+                        "column": 9
+                    },
+                    "end": {
+                        "line": 1,
+                        "column": 12
+                    }
+                },
+                "name": "foo"
+            },
+            "generator": false,
+            "expression": false,
+            "async": false,
+            "params": [],
+            "body": {
+                "type": "BlockStatement",
+                "range": [
+                    20,
+                    23
+                ],
+                "loc": {
+                    "start": {
+                        "line": 1,
+                        "column": 20
+                    },
+                    "end": {
+                        "line": 1,
+                        "column": 23
+                    }
+                },
+                "body": []
+            },
+            "returnType": {
+                "type": "TypeAnnotation",
+                "loc": {
+                    "start": {
+                        "line": 1,
+                        "column": 16
+                    },
+                    "end": {
+                        "line": 1,
+                        "column": 19
+                    }
+                },
+                "range": [
+                    16,
+                    19
+                ],
+                "typeAnnotation": {
+                    "type": "TypeReference",
+                    "range": [
+                        16,
+                        19
+                    ],
+                    "loc": {
+                        "start": {
+                            "line": 1,
+                            "column": 16
+                        },
+                        "end": {
+                            "line": 1,
+                            "column": 19
+                        }
+                    },
+                    "typeName": {
+                        "type": "Identifier",
+                        "range": [
+                            16,
+                            19
+                        ],
+                        "loc": {
+                            "start": {
+                                "line": 1,
+                                "column": 16
+                            },
+                            "end": {
+                                "line": 1,
+                                "column": 19
+                            }
+                        },
+                        "name": "Bar"
+                    }
+                }
+            }
+        }
+    ],
+    "sourceType": "script",
+    "tokens": [
+        {
+            "type": "Keyword",
+            "value": "function",
+            "start": 0,
+            "end": 8,
+            "range": [
+                0,
+                8
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 0
+                },
+                "end": {
+                    "line": 1,
+                    "column": 8
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "foo",
+            "start": 9,
+            "end": 12,
+            "range": [
+                9,
+                12
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 9
+                },
+                "end": {
+                    "line": 1,
+                    "column": 12
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "(",
+            "start": 12,
+            "end": 13,
+            "range": [
+                12,
+                13
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 12
+                },
+                "end": {
+                    "line": 1,
+                    "column": 13
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": ")",
+            "start": 13,
+            "end": 14,
+            "range": [
+                13,
+                14
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 13
+                },
+                "end": {
+                    "line": 1,
+                    "column": 14
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": ":",
+            "start": 14,
+            "end": 15,
+            "range": [
+                14,
+                15
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 14
+                },
+                "end": {
+                    "line": 1,
+                    "column": 15
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "Bar",
+            "start": 16,
+            "end": 19,
+            "range": [
+                16,
+                19
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 16
+                },
+                "end": {
+                    "line": 1,
+                    "column": 19
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "{",
+            "start": 20,
+            "end": 21,
+            "range": [
+                20,
+                21
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 20
+                },
+                "end": {
+                    "line": 1,
+                    "column": 21
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "}",
+            "start": 22,
+            "end": 23,
+            "range": [
+                22,
+                23
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 22
+                },
+                "end": {
+                    "line": 1,
+                    "column": 23
+                }
+            }
+        }
+    ],
+    "comments": []
+});

--- a/tests/fixtures/parsers/type-annotations/variable-declaration-init-type-annotation-no-space.js
+++ b/tests/fixtures/parsers/type-annotations/variable-declaration-init-type-annotation-no-space.js
@@ -1,0 +1,293 @@
+/**
+ * Source code:
+ * var a: Foo= b;
+ */
+
+exports.parse = () => ({
+    "type": "Program",
+    "range": [
+        0,
+        14
+    ],
+    "loc": {
+        "start": {
+            "line": 1,
+            "column": 0
+        },
+        "end": {
+            "line": 1,
+            "column": 14
+        }
+    },
+    "body": [
+        {
+            "type": "VariableDeclaration",
+            "range": [
+                0,
+                14
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 0
+                },
+                "end": {
+                    "line": 1,
+                    "column": 14
+                }
+            },
+            "declarations": [
+                {
+                    "type": "VariableDeclarator",
+                    "range": [
+                        4,
+                        13
+                    ],
+                    "loc": {
+                        "start": {
+                            "line": 1,
+                            "column": 4
+                        },
+                        "end": {
+                            "line": 1,
+                            "column": 13
+                        }
+                    },
+                    "id": {
+                        "type": "Identifier",
+                        "range": [
+                            4,
+                            5
+                        ],
+                        "loc": {
+                            "start": {
+                                "line": 1,
+                                "column": 4
+                            },
+                            "end": {
+                                "line": 1,
+                                "column": 5
+                            }
+                        },
+                        "name": "a",
+                        "typeAnnotation": {
+                            "type": "TypeAnnotation",
+                            "loc": {
+                                "start": {
+                                    "line": 1,
+                                    "column": 7
+                                },
+                                "end": {
+                                    "line": 1,
+                                    "column": 10
+                                }
+                            },
+                            "range": [
+                                7,
+                                10
+                            ],
+                            "typeAnnotation": {
+                                "type": "TypeReference",
+                                "range": [
+                                    7,
+                                    10
+                                ],
+                                "loc": {
+                                    "start": {
+                                        "line": 1,
+                                        "column": 7
+                                    },
+                                    "end": {
+                                        "line": 1,
+                                        "column": 10
+                                    }
+                                },
+                                "typeName": {
+                                    "type": "Identifier",
+                                    "range": [
+                                        7,
+                                        10
+                                    ],
+                                    "loc": {
+                                        "start": {
+                                            "line": 1,
+                                            "column": 7
+                                        },
+                                        "end": {
+                                            "line": 1,
+                                            "column": 10
+                                        }
+                                    },
+                                    "name": "Foo"
+                                }
+                            }
+                        }
+                    },
+                    "init": {
+                        "type": "Identifier",
+                        "range": [
+                            12,
+                            13
+                        ],
+                        "loc": {
+                            "start": {
+                                "line": 1,
+                                "column": 12
+                            },
+                            "end": {
+                                "line": 1,
+                                "column": 13
+                            }
+                        },
+                        "name": "b"
+                    }
+                }
+            ],
+            "kind": "var"
+        }
+    ],
+    "sourceType": "script",
+    "tokens": [
+        {
+            "type": "Keyword",
+            "value": "var",
+            "start": 0,
+            "end": 3,
+            "range": [
+                0,
+                3
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 0
+                },
+                "end": {
+                    "line": 1,
+                    "column": 3
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "a",
+            "start": 4,
+            "end": 5,
+            "range": [
+                4,
+                5
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 4
+                },
+                "end": {
+                    "line": 1,
+                    "column": 5
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": ":",
+            "start": 5,
+            "end": 6,
+            "range": [
+                5,
+                6
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 5
+                },
+                "end": {
+                    "line": 1,
+                    "column": 6
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "Foo",
+            "start": 7,
+            "end": 10,
+            "range": [
+                7,
+                10
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 7
+                },
+                "end": {
+                    "line": 1,
+                    "column": 10
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "=",
+            "start": 10,
+            "end": 11,
+            "range": [
+                10,
+                11
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 10
+                },
+                "end": {
+                    "line": 1,
+                    "column": 11
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "b",
+            "start": 12,
+            "end": 13,
+            "range": [
+                12,
+                13
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 12
+                },
+                "end": {
+                    "line": 1,
+                    "column": 13
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": ";",
+            "start": 13,
+            "end": 14,
+            "range": [
+                13,
+                14
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 13
+                },
+                "end": {
+                    "line": 1,
+                    "column": 14
+                }
+            }
+        }
+    ],
+    "comments": []
+});

--- a/tests/fixtures/parsers/type-annotations/variable-declaration-init-type-annotation.js
+++ b/tests/fixtures/parsers/type-annotations/variable-declaration-init-type-annotation.js
@@ -1,0 +1,294 @@
+/**
+ * Source code:
+ * var foo: Bar = '';
+ */
+
+exports.parse = () => ({
+    "type": "Program",
+    "range": [
+        0,
+        18
+    ],
+    "loc": {
+        "start": {
+            "line": 1,
+            "column": 0
+        },
+        "end": {
+            "line": 1,
+            "column": 18
+        }
+    },
+    "body": [
+        {
+            "type": "VariableDeclaration",
+            "range": [
+                0,
+                18
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 0
+                },
+                "end": {
+                    "line": 1,
+                    "column": 18
+                }
+            },
+            "declarations": [
+                {
+                    "type": "VariableDeclarator",
+                    "range": [
+                        4,
+                        17
+                    ],
+                    "loc": {
+                        "start": {
+                            "line": 1,
+                            "column": 4
+                        },
+                        "end": {
+                            "line": 1,
+                            "column": 17
+                        }
+                    },
+                    "id": {
+                        "type": "Identifier",
+                        "range": [
+                            4,
+                            7
+                        ],
+                        "loc": {
+                            "start": {
+                                "line": 1,
+                                "column": 4
+                            },
+                            "end": {
+                                "line": 1,
+                                "column": 7
+                            }
+                        },
+                        "name": "foo",
+                        "typeAnnotation": {
+                            "type": "TypeAnnotation",
+                            "loc": {
+                                "start": {
+                                    "line": 1,
+                                    "column": 9
+                                },
+                                "end": {
+                                    "line": 1,
+                                    "column": 12
+                                }
+                            },
+                            "range": [
+                                9,
+                                12
+                            ],
+                            "typeAnnotation": {
+                                "type": "TypeReference",
+                                "range": [
+                                    9,
+                                    12
+                                ],
+                                "loc": {
+                                    "start": {
+                                        "line": 1,
+                                        "column": 9
+                                    },
+                                    "end": {
+                                        "line": 1,
+                                        "column": 12
+                                    }
+                                },
+                                "typeName": {
+                                    "type": "Identifier",
+                                    "range": [
+                                        9,
+                                        12
+                                    ],
+                                    "loc": {
+                                        "start": {
+                                            "line": 1,
+                                            "column": 9
+                                        },
+                                        "end": {
+                                            "line": 1,
+                                            "column": 12
+                                        }
+                                    },
+                                    "name": "Bar"
+                                }
+                            }
+                        }
+                    },
+                    "init": {
+                        "type": "Literal",
+                        "range": [
+                            15,
+                            17
+                        ],
+                        "loc": {
+                            "start": {
+                                "line": 1,
+                                "column": 15
+                            },
+                            "end": {
+                                "line": 1,
+                                "column": 17
+                            }
+                        },
+                        "value": "",
+                        "raw": "''"
+                    }
+                }
+            ],
+            "kind": "var"
+        }
+    ],
+    "sourceType": "script",
+    "tokens": [
+        {
+            "type": "Keyword",
+            "value": "var",
+            "start": 0,
+            "end": 3,
+            "range": [
+                0,
+                3
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 0
+                },
+                "end": {
+                    "line": 1,
+                    "column": 3
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "foo",
+            "start": 4,
+            "end": 7,
+            "range": [
+                4,
+                7
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 4
+                },
+                "end": {
+                    "line": 1,
+                    "column": 7
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": ":",
+            "start": 7,
+            "end": 8,
+            "range": [
+                7,
+                8
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 7
+                },
+                "end": {
+                    "line": 1,
+                    "column": 8
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "Bar",
+            "start": 9,
+            "end": 12,
+            "range": [
+                9,
+                12
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 9
+                },
+                "end": {
+                    "line": 1,
+                    "column": 12
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "=",
+            "start": 13,
+            "end": 14,
+            "range": [
+                13,
+                14
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 13
+                },
+                "end": {
+                    "line": 1,
+                    "column": 14
+                }
+            }
+        },
+        {
+            "type": "String",
+            "value": "''",
+            "start": 15,
+            "end": 17,
+            "range": [
+                15,
+                17
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 15
+                },
+                "end": {
+                    "line": 1,
+                    "column": 17
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": ";",
+            "start": 17,
+            "end": 18,
+            "range": [
+                17,
+                18
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 17
+                },
+                "end": {
+                    "line": 1,
+                    "column": 18
+                }
+            }
+        }
+    ],
+    "comments": []
+});

--- a/tests/fixtures/parsers/typescript-parsers/type-alias.js
+++ b/tests/fixtures/parsers/typescript-parsers/type-alias.js
@@ -1,0 +1,155 @@
+"use strict";
+
+exports.parse = () => ({
+    type: "Program",
+    range: [0, 16],
+    loc: {
+        start: { line: 1, column: 0 },
+        end: { line: 1, column: 16 }
+    },
+    body: [
+        {
+            type: "VariableDeclaration",
+            range: [0, 16],
+            loc: {
+                start: { line: 1, column: 0 },
+                end: { line: 1, column: 16 }
+            },
+            kind: "type",
+            declarations: [
+                {
+                    type: "VariableDeclarator",
+                    id: {
+                        type: "Identifier",
+                        range: [
+                            5,
+                            8
+                        ],
+                        loc: {
+                            start: { line: 1, column: 5 },
+                            end: { line: 1, column: 8 }
+                        },
+                        name: "Foo"
+                    },
+                    init: {
+                        type: "TSTypeReference",
+                        range: [14, 15],
+                        loc: {
+                            start: { line: 1, column: 14 },
+                            end: { line: 1, column: 15 }
+                        },
+                        typeName: {
+                            type: "Identifier",
+                            range: [14, 15],
+                            loc: {
+                                start: { line: 1, column: 14 },
+                                end: { line: 1, column: 15 }
+                            },
+                            name: "T"
+                        }
+                    },
+                    range: [5, 16],
+                    loc: {
+                        start: { line: 1, column: 5 },
+                        end: { line: 1, column: 16 }
+                    },
+                    typeParameters: {
+                        type: "TSTypeParameterDeclaration",
+                        range: [8, 11],
+                        loc: {
+                            start: { line: 1, column: 8 },
+                            end: { line: 1, column: 11 }
+                        },
+                        params: [
+                            {
+                                type: "TSTypeParameter",
+                                range: [9, 10],
+                                loc: {
+                                    start: { line: 1, column: 9 },
+                                    end: { line: 1, column: 10 }
+                                },
+                                name: "T"
+                            }
+                        ]
+                    }
+                }
+            ]
+        }
+    ],
+    sourceType: "script",
+    tokens: [
+        {
+            type: "Identifier",
+            value: "type",
+            range: [0, 4],
+            loc: {
+                start: { line: 1, column: 0 },
+                end: { line: 1, column: 4 }
+            }
+        },
+        {
+            type: "Identifier",
+            value: "Foo",
+            range: [5, 8],
+            loc: {
+                start: { line: 1, column: 5 },
+                end: { line: 1, column: 8 }
+            }
+        },
+        {
+            type: "Punctuator",
+            value: "<",
+            range: [8, 9],
+            loc: {
+                start: { line: 1, column: 8 },
+                end: { line: 1, column: 9 }
+            }
+        },
+        {
+            type: "Identifier",
+            value: "T",
+            range: [9, 10],
+            loc: {
+                start: { line: 1, column: 9 },
+                end: { line: 1, column: 10 }
+            }
+        },
+        {
+            type: "Punctuator",
+            value: ">",
+            range: [10, 11],
+            loc: {
+                start: { line: 1, column: 10 },
+                end: { line: 1, column: 11 }
+            }
+        },
+        {
+            type: "Punctuator",
+            value: "=",
+            range: [12, 13],
+            loc: {
+                start: { line: 1, column: 12 },
+                end: { line: 1, column: 13 }
+            }
+        },
+        {
+            type: "Identifier",
+            value: "T",
+            range: [14, 15],
+            loc: {
+                start: { line: 1, column: 14 },
+                end: { line: 1, column: 15 }
+            }
+        },
+        {
+            type: "Punctuator",
+            value: ";",
+            range: [15, 16],
+            loc: {
+                start: { line: 1, column: 15 },
+                end: { line: 1, column: 16 }
+            }
+        }
+    ],
+    comments: []
+})

--- a/tests/rules/space-infix-ops.js
+++ b/tests/rules/space-infix-ops.js
@@ -1,0 +1,471 @@
+/**
+ * @fileoverview Require spaces around infix operators
+ * @author Michael Ficarra
+ */
+
+"use strict";
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+const rule = require("../../rules/space-infix-ops"),
+    RuleTester = require("../RuleTester"),
+    parser = require("../fixtures/fixture-parser");
+
+const ruleTester = new RuleTester();
+
+ruleTester.run("space-infix-ops", rule, {
+    valid: [
+        "a + b",
+        "a + ++b",
+        "a++ + b",
+        "a++ + ++b",
+        "a     + b",
+        "(a) + (b)",
+        "((a)) + ((b))",
+        "(((a))) + (((b)))",
+        "a + +b",
+        "a + (b)",
+        "a + +(b)",
+        "a + (+(b))",
+        "(a + b) + (c + d)",
+        "a = b",
+        "a ? b : c",
+        "var a = b",
+        { code: "const my_object = {key: 'value'};", parserOptions: { ecmaVersion: 6 } },
+        { code: "var {a = 0} = bar;", parserOptions: { ecmaVersion: 6 } },
+        { code: "function foo(a = 0) { }", parserOptions: { ecmaVersion: 6 } },
+        { code: "a ** b", parserOptions: { ecmaVersion: 7 } },
+        { code: "a|0", options: [{ int32Hint: true }] },
+        { code: "a |0", options: [{ int32Hint: true }] },
+
+        // Type Annotations
+        { code: "function foo(a: number = 0) { }", parserOptions: { ecmaVersion: 6 }, parser: parser("type-annotations/function-parameter-type-annotation") },
+        { code: "function foo(): Bar { }", parserOptions: { ecmaVersion: 6 }, parser: parser("type-annotations/function-return-type-annotation") },
+        { code: "var foo: Bar = '';", parserOptions: { ecmaVersion: 6 }, parser: parser("type-annotations/variable-declaration-init-type-annotation") },
+        { code: "const foo = function(a: number = 0): Bar { };", parserOptions: { ecmaVersion: 6 }, parser: parser("type-annotations/function-expression-type-annotation") },
+
+        // TypeScript Type Aliases
+        { code: "type Foo<T> = T;", parserOptions: { ecmaVersion: 6 }, parser: parser("typescript-parsers/type-alias") },
+
+        { code: "class A { static foo = 1 }", parserOptions: { ecmaVersion: 6 } },
+        { code: "class A { foo = 1 }", parserOptions: { ecmaVersion: 6 } },
+
+        { code: "class A { foo: number = 1 }", parserOptions: { ecmaVersion: 6 }, parser: parser("type-annotations/class-property-type-annotation") }
+    ],
+    invalid: [
+        {
+            code: "a+b",
+            output: "a + b",
+            errors: [{
+                message: "Operator '+' must be spaced.",
+                type: "BinaryExpression",
+                line: 1,
+                column: 2
+            }]
+        },
+        {
+            code: "a +b",
+            output: "a + b",
+            errors: [{
+                message: "Operator '+' must be spaced.",
+                type: "BinaryExpression",
+                line: 1,
+                column: 3
+            }]
+        },
+        {
+            code: "a+ b",
+            output: "a + b",
+            errors: [{
+                message: "Operator '+' must be spaced.",
+                type: "BinaryExpression",
+                line: 1,
+                column: 2
+            }]
+        },
+        {
+            code: "a||b",
+            output: "a || b",
+            errors: [{
+                message: "Operator '||' must be spaced.",
+                type: "LogicalExpression",
+                line: 1,
+                column: 2
+            }]
+        },
+        {
+            code: "a ||b",
+            output: "a || b",
+            errors: [{
+                message: "Operator '||' must be spaced.",
+                type: "LogicalExpression",
+                line: 1,
+                column: 3
+            }]
+        },
+        {
+            code: "a|| b",
+            output: "a || b",
+            errors: [{
+                message: "Operator '||' must be spaced.",
+                type: "LogicalExpression",
+                line: 1,
+                column: 2
+            }]
+        },
+        {
+            code: "a=b",
+            output: "a = b",
+            errors: [{
+                message: "Operator '=' must be spaced.",
+                type: "AssignmentExpression",
+                line: 1,
+                column: 2
+            }]
+        },
+        {
+            code: "a= b",
+            output: "a = b",
+            errors: [{
+                message: "Operator '=' must be spaced.",
+                type: "AssignmentExpression",
+                line: 1,
+                column: 2
+            }]
+        },
+        {
+            code: "a =b",
+            output: "a = b",
+            errors: [{
+                message: "Operator '=' must be spaced.",
+                type: "AssignmentExpression",
+                line: 1,
+                column: 3
+            }]
+        },
+        {
+            code: "a?b:c",
+            output: "a ? b:c",
+            errors: [{
+                message: "Operator '?' must be spaced.",
+                type: "ConditionalExpression",
+                line: 1,
+                column: 2
+            }]
+        },
+        {
+            code: "a?b : c",
+            output: "a ? b : c",
+            errors: [{
+                message: "Operator '?' must be spaced.",
+                type: "ConditionalExpression",
+                line: 1,
+                column: 2
+            }]
+        },
+        {
+            code: "a ? b:c",
+            output: "a ? b : c",
+            errors: [{
+                message: "Operator ':' must be spaced.",
+                type: "ConditionalExpression",
+                line: 1,
+                column: 6
+            }]
+        },
+        {
+            code: "a? b : c",
+            output: "a ? b : c",
+            errors: [{
+                message: "Operator '?' must be spaced.",
+                type: "ConditionalExpression",
+                line: 1,
+                column: 2
+            }]
+        },
+        {
+            code: "a ?b : c",
+            output: "a ? b : c",
+            errors: [{
+                message: "Operator '?' must be spaced.",
+                type: "ConditionalExpression",
+                line: 1,
+                column: 3
+            }]
+        },
+        {
+            code: "a ? b: c",
+            output: "a ? b : c",
+            errors: [{
+                message: "Operator ':' must be spaced.",
+                type: "ConditionalExpression",
+                line: 1,
+                column: 6
+            }]
+        },
+        {
+            code: "a ? b :c",
+            output: "a ? b : c",
+            errors: [{
+                message: "Operator ':' must be spaced.",
+                type: "ConditionalExpression",
+                line: 1,
+                column: 7
+            }]
+        },
+        {
+            code: "var a=b;",
+            output: "var a = b;",
+            errors: [{
+                message: "Operator '=' must be spaced.",
+                type: "VariableDeclarator",
+                line: 1,
+                column: 6
+            }]
+        },
+        {
+            code: "var a= b;",
+            output: "var a = b;",
+            errors: [{
+                message: "Operator '=' must be spaced.",
+                type: "VariableDeclarator",
+                line: 1,
+                column: 6
+            }]
+        },
+        {
+            code: "var a =b;",
+            output: "var a = b;",
+            errors: [{
+                message: "Operator '=' must be spaced.",
+                type: "VariableDeclarator",
+                line: 1,
+                column: 7
+            }]
+        },
+        {
+            code: "var a = b, c=d;",
+            output: "var a = b, c = d;",
+            errors: [{
+                message: "Operator '=' must be spaced.",
+                type: "VariableDeclarator",
+                line: 1,
+                column: 13
+            }]
+        },
+        {
+            code: "a| 0",
+            output: "a | 0",
+            options: [{
+                int32Hint: true
+            }],
+            errors: [{
+                message: "Operator '|' must be spaced.",
+                type: "BinaryExpression",
+                line: 1,
+                column: 2
+            }]
+        },
+        {
+            code: "var output = test || (test && test.value) ||(test2 && test2.value);",
+            output: "var output = test || (test && test.value) || (test2 && test2.value);",
+            errors: [{
+                message: "Operator '||' must be spaced.",
+                type: "LogicalExpression",
+                line: 1,
+                column: 43
+            }]
+        },
+        {
+            code: "var output = a ||(b && c.value) || (d && e.value);",
+            output: "var output = a || (b && c.value) || (d && e.value);",
+            errors: [{
+                message: "Operator '||' must be spaced.",
+                type: "LogicalExpression",
+                line: 1,
+                column: 16
+            }]
+        },
+        {
+            code: "var output = a|| (b && c.value) || (d && e.value);",
+            output: "var output = a || (b && c.value) || (d && e.value);",
+            errors: [{
+                message: "Operator '||' must be spaced.",
+                type: "LogicalExpression",
+                line: 1,
+                column: 15
+            }]
+        },
+        {
+            code: "const my_object={key: 'value'}",
+            output: "const my_object = {key: 'value'}",
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{
+                message: "Operator '=' must be spaced.",
+                type: "VariableDeclarator",
+                line: 1,
+                column: 16
+            }]
+        },
+        {
+            code: "var {a=0}=bar;",
+            output: "var {a = 0} = bar;",
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{
+                message: "Operator '=' must be spaced.",
+                line: 1,
+                column: 7,
+                nodeType: "AssignmentPattern"
+            }, {
+                message: "Operator '=' must be spaced.",
+                line: 1,
+                column: 10,
+                nodeType: "VariableDeclarator"
+            }]
+        },
+        {
+            code: "function foo(a=0) { }",
+            output: "function foo(a = 0) { }",
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{
+                message: "Operator '=' must be spaced.",
+                line: 1,
+                column: 15,
+                nodeType: "AssignmentPattern"
+            }]
+        },
+        {
+            code: "a**b",
+            output: "a ** b",
+            parserOptions: { ecmaVersion: 7 },
+            errors: [{
+                message: "Operator '**' must be spaced.",
+                line: 1,
+                column: 2,
+                nodeType: "BinaryExpression"
+            }]
+        },
+        {
+            code: "'foo'in{}",
+            output: "'foo' in {}",
+            errors: [{
+                message: "Operator 'in' must be spaced.",
+                line: 1,
+                column: 6,
+                nodeType: "BinaryExpression"
+            }]
+        },
+        {
+            code: "'foo'instanceof{}",
+            output: "'foo' instanceof {}",
+            errors: [{
+                message: "Operator 'instanceof' must be spaced.",
+                line: 1,
+                column: 6,
+                nodeType: "BinaryExpression"
+            }]
+        },
+
+        // Type Annotations
+
+        {
+            code: "var a: Foo= b;",
+            output: "var a: Foo = b;",
+            errors: [{
+                message: "Operator '=' must be spaced.",
+                type: "VariableDeclarator",
+                line: 1,
+                column: 11
+            }],
+            parser: parser("type-annotations/variable-declaration-init-type-annotation-no-space")
+        },
+        {
+            code: "function foo(a: number=0): Foo { }",
+            output: "function foo(a: number = 0): Foo { }",
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{
+                message: "Operator '=' must be spaced.",
+                line: 1,
+                column: 23,
+                nodeType: "AssignmentPattern"
+            }],
+            parser: parser("type-annotations/function-declaration-type-annotation-no-space")
+        },
+
+
+        {
+            code: "class A { static foo=bar }",
+            output: "class A { static foo = bar }",
+            errors: [{
+                message: "Operator '=' must be spaced.",
+                type: "ClassProperty",
+                line: 1,
+                column: 21
+            }]
+        },
+        {
+            code: "class A { static foo =bar }",
+            output: "class A { static foo = bar }",
+            errors: [{
+                message: "Operator '=' must be spaced.",
+                type: "ClassProperty",
+                line: 1,
+                column: 22
+            }]
+        },
+        {
+            code: "class A { static foo= bar }",
+            output: "class A { static foo = bar }",
+            errors: [{
+                message: "Operator '=' must be spaced.",
+                type: "ClassProperty",
+                line: 1,
+                column: 21
+            }]
+        },
+        {
+            code: "class A { foo=bar }",
+            output: "class A { foo = bar }",
+            errors: [{
+                message: "Operator '=' must be spaced.",
+                type: "ClassProperty",
+                line: 1,
+                column: 14
+            }]
+        },
+        {
+            code: "class A { foo =bar }",
+            output: "class A { foo = bar }",
+            errors: [{
+                message: "Operator '=' must be spaced.",
+                type: "ClassProperty",
+                line: 1,
+                column: 15
+            }]
+        },
+        {
+            code: "class A { foo= bar }",
+            output: "class A { foo = bar }",
+            errors: [{
+                message: "Operator '=' must be spaced.",
+                type: "ClassProperty",
+                line: 1,
+                column: 14
+            }]
+        },
+
+        {
+            code: "class A { foo: Bar=bar }",
+            output: "class A { foo: Bar = bar }",
+            errors: [{
+                message: "Operator '=' must be spaced.",
+                type: "ClassProperty",
+                line: 1,
+                column: 19
+            }],
+            parser: parser("type-annotations/class-property-type-annotation-no-space")
+        },
+    ]
+});


### PR DESCRIPTION
Should support static and instance properties with and without types.

Note to reviewer:
like all rules in this repo, most of the code for this rule was copy-pasted from original eslint repo

The parts that were added begin here:
- https://github.com/babel/eslint-plugin-babel/pull/170/files#diff-3f067e59f88ec6ac7a89c7eae9943ff0R154
- https://github.com/babel/eslint-plugin-babel/pull/170/files#diff-7a29ae35b4c8671d5134f8f375bf2c9dR52
- https://github.com/babel/eslint-plugin-babel/pull/170/files#diff-7a29ae35b4c8671d5134f8f375bf2c9dR398