### PR TITLE
Support private properties in no-invalid-this

### DIFF
--- a/rules/no-invalid-this.js
+++ b/rules/no-invalid-this.js
@@ -5,17 +5,18 @@ const eslint = require('eslint');
 const noInvalidThisRule = new eslint.Linter().getRules().get('no-invalid-this');
 
 module.exports = ruleComposer.filterReports(
-    noInvalidThisRule,    
+    noInvalidThisRule,
     (problem, metadata) => {
         let inClassProperty = false;
         let node = problem.node;
 
         while (node) {
-            if (node.type === "ClassProperty") {
+            if (node.type === "ClassProperty" ||
+                node.type === "ClassPrivateProperty") {
                 inClassProperty = true;
                 return;
             }
-            
+
             node = node.parent;
         }
 

--- a/tests/rules/no-invalid-this.js
+++ b/tests/rules/no-invalid-this.js
@@ -602,6 +602,21 @@ const patterns = [
         valid: [NORMAL, USE_STRICT, IMPLIED_STRICT, MODULES],
         invalid: []
     },
+
+    // Class Private Instance Properties.
+    {
+        code: "class A {#a = this.b;};",
+        parserOptions: { ecmaVersion: 6 },
+        valid: [NORMAL, USE_STRICT, IMPLIED_STRICT, MODULES],
+        invalid: []
+    },
+
+    {
+        code: "class A {#a = () => {return this.b;};};",
+        parserOptions: { ecmaVersion: 6 },
+        valid: [NORMAL, USE_STRICT, IMPLIED_STRICT, MODULES],
+        invalid: []
+    },
 ];
 
 const ruleTester = new RuleTester();


### PR DESCRIPTION
Closes #182 

Also count `node.type === ClassPrivateProperty` as being a class property.