### PR TITLE
Class fields with lines-between-class-members

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ original ones as well!).
   "rules": {
     "babel/new-cap": 1,
     "babel/camelcase": 1,
+    "babel/lines-between-class-members": 1,
     "babel/no-invalid-this": 1,
     "babel/object-curly-spacing": 1,
     "babel/quotes": 1,
@@ -46,7 +47,8 @@ Each rule corresponds to a core `eslint` rule, and has the same options.
 🛠: means it's autofixable with `--fix`.
 
 - `babel/new-cap`: Ignores capitalized decorators (`@Decorator`)
-- `babel/camelcase: doesn't complain about optional chaining (`var foo = bar?.a_b;`)
+- `babel/camelcase`: doesn't complain about optional chaining (`var foo = bar?.a_b;`)
+- `babel/lines-between-class-members`: doesn't complain about public/private class fields (🛠)
 - `babel/no-invalid-this`: doesn't fail when inside class properties (`class A { a = this.b; }`)
 - `babel/object-curly-spacing`: doesn't complain about `export x from "mod";` or `export * as x from "mod";` (🛠)
 - `babel/quotes`: doesn't complain about JSX fragment shorthand syntax (`<>foo</>;`)

--- a/rules/lines-between-class-members.js
+++ b/rules/lines-between-class-members.js
@@ -1,0 +1,24 @@
+"use strict";
+
+const ruleComposer = require('eslint-rule-composer');
+const eslint = require('eslint');
+const rule = new eslint.Linter().getRules().get('lines-between-class-members');
+
+module.exports = ruleComposer.filterReports(
+    rule,
+    (problem, metadata) => {
+        let inClassProperty = false;
+        let node = problem.node;
+
+        while (node) {
+            if (node.type === "ClassProperty" || node.type === "ClassPrivateProperty") {
+                inClassProperty = true;
+                return;
+            }
+
+            node = node.parent;
+        }
+
+        return !inClassProperty;
+    }
+);

--- a/tests/rules/lines-between-class-members.js
+++ b/tests/rules/lines-between-class-members.js
@@ -1,0 +1,90 @@
+/**
+ * @fileoverview Tests for lines-between-class-members rule.
+ * @author 薛定谔的猫<hh_2013@foxmail.com>
+ * @author Aparajita Fishman
+ */
+
+"use strict";
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+const rule = require("../../rules/lines-between-class-members"),
+    RuleTester = require("../RuleTester");
+
+//------------------------------------------------------------------------------
+// Helpers
+//------------------------------------------------------------------------------
+const messages = {
+    never: "Unexpected blank line between class members.",
+    always: "Expected blank line between class members."
+};
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+const ruleTester = new RuleTester();
+
+ruleTester.run("lines-between-class-members", rule, {
+    valid: [
+        "class foo{}",
+        "class foo{;;}",
+        "class foo{\n\n}",
+        "class foo{constructor(){}\n}",
+        "class foo{\nconstructor(){}}",
+
+        "class foo{ bar(){}\n\nbaz(){}}",
+        "class foo{ bar(){}\n\n/*comments*/baz(){}}",
+        "class foo{ bar(){}\n\n//comments\nbaz(){}}",
+        "class foo{ bar(){}\n//comments\n\nbaz(){}}",
+        "class A{ foo() {} // a comment\n\nbar() {}}",
+        "class A{ foo() {}\n/* a */ /* b */\n\nbar() {}}",
+        "class A{ foo() {}/* a */ \n\n /* b */bar() {}}",
+
+        "class foo{ bar(){}\n\n;;baz(){}}",
+        "class foo{ bar(){};\n\nbaz(){}}",
+
+        // Class fields
+        "class foo{ bar\nbaz = 7\n\nboo(){}}",
+        "class foo{ bar = 13\nbaz\n\nboo(){}}",
+        "class foo{ bar;\nbaz;\n\nboo(){}}",
+        "class foo{ bar;baz;\n\nboo(){}}",
+        "class foo{ #bar\nbaz\n\nboo(){}}",
+        "class foo{ #bar\n#baz\n\nboo(){}}",
+        "class foo{ #bar\n\nboo(){}\n\n#boo\nhoo}",
+
+        { code: "class foo{ bar(){}\nbaz(){}}", options: ["never"] },
+        { code: "class foo{ bar(){}\n/*comments*/baz(){}}", options: ["never"] },
+        { code: "class foo{ bar(){}\n//comments\nbaz(){}}", options: ["never"] },
+        { code: "class foo{ bar(){}/* comments\n\n*/baz(){}}", options: ["never"] },
+        { code: "class foo{ bar(){}/* \ncomments\n*/baz(){}}", options: ["never"] },
+        { code: "class foo{ bar(){}\n/* \ncomments\n*/\nbaz(){}}", options: ["never"] },
+
+        { code: "class foo{ bar(){}\n\nbaz(){}}", options: ["always"] },
+        { code: "class foo{ bar(){}\n\n/*comments*/baz(){}}", options: ["always"] },
+        { code: "class foo{ bar(){}\n\n//comments\nbaz(){}}", options: ["always"] },
+
+        { code: "class foo{ bar(){}\nbaz(){}}", options: ["always", { exceptAfterSingleLine: true }] },
+        { code: "class foo{ bar(){\n}\n\nbaz(){}}", options: ["always", { exceptAfterSingleLine: true }] }
+    ],
+    invalid: [
+        {
+            code: "class foo{ boo\n#hoo\n\nbar(){}\nbaz(){}}",
+            output: "class foo{ boo\n#hoo\n\nbar(){}\n\nbaz(){}}",
+            options: ["always"],
+            errors: [messages.always]
+        }, {
+            code: "class foo{ boo\n#hoo\nbar(){}\n\nbaz(){}}",
+            output: "class foo{ boo\n#hoo\nbar(){}\nbaz(){}}",
+            options: ["never"],
+            errors: [messages.never]
+        }, {
+            code: "class foo{ boo\n#hoo\n\nbar(){\n}\nbaz(){}}",
+            output: "class foo{ boo\n#hoo\n\nbar(){\n}\n\nbaz(){}}",
+            options: ["always", { exceptAfterSingleLine: true }],
+            errors: [messages.always]
+        }
+    ]
+});


### PR DESCRIPTION
Currently the eslint `lines-between-class-members` does not support class fields because they are still Stage 3 (although widely supported).

This rule eliminates errors for class fields which are on subsequent lines.