### PR TITLE
Ignore pipelines

### DIFF
--- a/rules/no-unused-expressions.js
+++ b/rules/no-unused-expressions.js
@@ -55,9 +55,23 @@ function isOptionalCallExpression(node) {
   );
 }
 
+/**
+ * @param {ASTNode} node - any node
+ * @return {boolean} whether the expression is a pipeline,
+ *  https://github.com/tc39/proposal-pipeline-operator
+ */
+function isPipeline(node) {
+  return (
+    !!node &&
+    node.type === 'ExpressionStatement' &&
+    node.expression.type === 'BinaryExpression' &&
+    node.expression.operator === '|>'
+  )
+}
+
 module.exports = ruleComposer.filterReports(
   rule,
   (problem, metadata) =>
-    !isInDoStatement(problem.node) && !isOptionalCallExpression(problem.node)
+    !isInDoStatement(problem.node) && !isOptionalCallExpression(problem.node) && !isPipeline(problem.node)
 );
 

--- a/tests/rules/no-unused-expressions.js
+++ b/tests/rules/no-unused-expressions.js
@@ -81,7 +81,8 @@ ruleTester.run("no-unused-expressions", rule, {
         "let a = do { if (foo) { if (foo.bar) { foo.bar; } } }",
         "let a = do { if (foo) { if (foo.bar) { foo.bar; } else if (foo.baz) { foo.baz; } } }",
         "foo.bar?.();",
-
+        "x = 2 |> double |> addOne |> triple",
+        "1 |> incr |> triple |> print",
     ],
     invalid: [
         { code: "0", errors: [{ message: "Expected an assignment or function call and instead saw an expression.", type: "ExpressionStatement" }] },
@@ -139,6 +140,5 @@ ruleTester.run("no-unused-expressions", rule, {
         // Babel-specific test cases.
         { code: "let a = do { foo; let b = 2; }", errors: [{ message: "Expected an assignment or function call and instead saw an expression.", type: "ExpressionStatement" }] },
         { code: "let a = do { if (foo) { foo.bar } else { a; bar.foo } }", errors: [{ message: "Expected an assignment or function call and instead saw an expression.", type: "ExpressionStatement" }] },
-
     ]
 });


### PR DESCRIPTION
This fixes issue #174 and disables the no-used-expression warning for pipelines using the |> operator.