### PR TITLE
Fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Each rule corresponds to a core `eslint` rule, and has the same options.
 🛠: means it's autofixable with `--fix`.
 
 - `babel/new-cap`: Ignores capitalized decorators (`@Decorator`)
-- `babel/camelcase: doesn't complain about optional chaining (`var foo = bar?.a_b;`)
+- `babel/camelcase`: doesn't complain about optional chaining (`var foo = bar?.a_b;`)
 - `babel/no-invalid-this`: doesn't fail when inside class properties (`class A { a = this.b; }`)
 - `babel/object-curly-spacing`: doesn't complain about `export x from "mod";` or `export * as x from "mod";` (🛠)
 - `babel/quotes`: doesn't complain about JSX fragment shorthand syntax (`<>foo</>;`)


### PR DESCRIPTION
Missing a backtick (`) in the README